### PR TITLE
Add inverter data and component/inventory queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # Solaredge
+
 API wrapper for Solaredge monitoring service.
 
-See https://www.solaredge.com/sites/default/files/se_monitoring_api.pdf
+See <https://www.solaredge.com/sites/default/files/se_monitoring_api.pdf>
 
 ## Create a new connection by supplying your Solaredge API key
+
 ```
 s = solaredge.Solaredge("APIKEY")
 ```
 
 ## API Requests
-11 API requests are supported. The methods return the parsed JSON response as a dict.
+
+14 API requests are supported. The methods return the parsed JSON response as a dict.
 
 ```
 def get_list(self, size=100, startIndex=0, searchText="", sortProperty="", sortOrder='ASC', status='Active,Pending'):
@@ -33,8 +36,15 @@ def get_energyDetails(self, site_id, startTime, endTime, meters=None, timeUnit="
 def get_currentPowerFlow(self, site_id):
 
 def get_storageData(self, site_id, startTime, endTime, serials=None):
+
+get_componentList(self, site_id):
+
+get_inventory(self, site_id):
+
+def get_invertorDetails(self, site_id, invertor_id, startTime, endTime):
 ```
 
 ## TODO
-* Add support for bulk requests
-* Add API documentation
+
+- Add support for bulk requests
+- Add API documentation

--- a/solaredge/solaredge.py
+++ b/solaredge/solaredge.py
@@ -201,6 +201,38 @@ class Solaredge(object):
         r.raise_for_status()
         return r.json()
 
+    def get_componentList(self, site_id):
+        url = urljoin(BASEURL, "equipment", site_id, "list")
+        params = {
+            'api_key': self.token 
+        }
+
+        r = requests.get(url, params)
+        r.raise_for_status()
+        return r.json()
+
+    def get_inventory(self, site_id):
+        url = urljoin(BASEURL, "site", site_id, "inventory")
+        params = {
+            'api_key': self.token
+        }
+
+        r = requests.get(url, params)
+        r.raise_for_status()
+        return r.json()
+
+    def get_inverterDetails(self, site_id, invertor_id, startTime, endTime):
+        url = urljoin(BASEURL, "equipment", site_id, invertor_id, "data")
+        params = {
+            'api_key': self.token,
+            'startTime': startTime,
+            'endTime': endTime,
+        }
+
+        r = requests.get(url, params)
+        r.raise_for_status()
+        return r.json()
+
 
 def urljoin(*parts):
     """

--- a/solaredge/solaredge.py
+++ b/solaredge/solaredge.py
@@ -204,7 +204,7 @@ class Solaredge(object):
     def get_componentList(self, site_id):
         url = urljoin(BASEURL, "equipment", site_id, "list")
         params = {
-            'api_key': self.token 
+            'api_key': self.token
         }
 
         r = requests.get(url, params)
@@ -221,8 +221,8 @@ class Solaredge(object):
         r.raise_for_status()
         return r.json()
 
-    def get_inverterDetails(self, site_id, invertor_id, startTime, endTime):
-        url = urljoin(BASEURL, "equipment", site_id, invertor_id, "data")
+    def get_inverterDetails(self, site_id, inverter_id, startTime, endTime):
+        url = urljoin(BASEURL, "equipment", site_id, inverter_id, "data")
         params = {
             'api_key': self.token,
             'startTime': startTime,


### PR DESCRIPTION
In order to obtain inverter historical data the component/inventory queries are needed to obtain the inverter_id which can then be used to obtain historical information including voltage data etc