### PR TITLE
chore: drop unused pytz dep, let dependabot manage pre-commit revs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,3 +10,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -16,10 +16,10 @@ jobs:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up UV
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: sync venv and build package with uv
         run: |
@@ -27,4 +27,4 @@ jobs:
           uv build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -9,8 +9,8 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
 
   test:
     runs-on: ubuntu-latest
@@ -19,15 +19,15 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: uv sync
@@ -36,6 +36,6 @@ jobs:
         run: uv run pytest --cov=src/solaredge --cov-branch --cov-report=xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # To update pre-commit hooks run:
-# uv run pre-commit autoupdate
+# uv run pre-commit autoupdate --freeze
 
 repos:
 -   hooks:
@@ -7,15 +7,15 @@ repos:
     -   id: check-toml
     -   id: no-commit-to-branch
     repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
 -   hooks:
     -   id: ruff-check
     -   id: ruff-format
     repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.5
+    rev: 1f1e8bf348ff38fc88619a38d3ca4d9c56abea49 # frozen: v0.16.5
 -   hooks:
     -   id: commitizen
         stages:
         - commit-msg
     repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.18.0
+    rev: d910b66e2686a3ef6c3f438dec0f63ba3cf8d7ee # frozen: v4.18.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "pytz>=2026.2",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

- **Drop the `pytz` runtime dependency.** It's declared in `pyproject.toml` but never imported anywhere in `src/` — there's no timezone handling in this codebase at all. Keeping it only forced an unnecessarily high `tzdata` floor on consumers for a package this library doesn't use. If timezone support is ever needed, stdlib `zoneinfo` covers it (project already requires Python `>=3.10`). This obsoletes #90 (the dependabot `pytz` version bump), which I'm closing as no longer applicable.
- **Move pre-commit hook-rev updates to Dependabot.** Added `package-ecosystem: "pre-commit"` to `.github/dependabot.yaml`, since Dependabot now natively supports bumping `.pre-commit-config.yaml` revisions. This is meant to replace the pre-commit.ci autoupdate PRs (like #91) going forward with a single, consistent update mechanism (Dependabot) across pip, github-actions, and pre-commit.
- **Pin GitHub Actions and pre-commit hooks to commit SHAs instead of mutable tags.** `actions/checkout@v7`, `astral-sh/setup-uv@v7`, `actions/setup-python@v7`, `codecov/codecov-action@v7`, `astral-sh/ruff-action@v3`, and `pypa/gh-action-pypi-publish@release/v1` in the two workflows, plus `pre-commit/pre-commit-hooks`, `astral-sh/ruff-pre-commit`, and `commitizen-tools/commitizen` in `.pre-commit-config.yaml`, are now pinned to the exact commit SHA each tag/branch currently resolves to, with the version kept as a trailing comment. This closes a supply-chain gap: a mutable tag can be moved to different code after review, a SHA can't. Dependabot's `github-actions` and `pre-commit` ecosystems both understand this comment convention and will keep bumping the SHA + comment together going forward.

## Follow-up needed (not doable from this session)

Fully retiring pre-commit.ci also means uninstalling/removing repo access for the **pre-commit.ci GitHub App** on this repository. That's an account/org-level setting (GitHub Settings → Integrations → Applications, or org GitHub Apps settings) that I don't have tooling to change from here — someone with admin access on the repo/org needs to do that part manually. Once it's removed, the `pre-commit.ci` check and its autoupdate PRs will stop appearing, and Dependabot's `pre-commit` ecosystem entry added here will take over.

## Testing

- `uv sync` — resolves cleanly without `pytz`
- `uv run ruff check .` — passes
- `uv run pytest -q` — 2 passed
- `uv run pre-commit run --all-files` — all three SHA-pinned hook repos install and run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8