### PR TITLE
fix: request-handling bugs, test suite, py.typed, ruff rule selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,11 @@ dependencies = [
 
 [dependency-groups]
 dev = ["commitizen", "pre-commit"]
-test = ["pytest", "pytest-cov"]
+test = ["pytest", "pytest-asyncio", "pytest-cov"]
 validate = ["ruff"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.uv]
 required-version = ">=0.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,15 +58,21 @@ ignore = [
     "D212",    #multi-line-summary-first-line
 ]
 select = [
+    "A",   # flake8-builtins
+    "B",   # flake8-bugbear
     "I",   # isort
-    "F",   # plake8-bugbear
-    "E",   # pycoyflakes
-    "W",
+    "F",   # pyflakes
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
     "D",   # pydocstyle
     "PL",  # pylint
     "RUF", # ruff
     "UP",  # pyupgrade
 ]
+[tool.ruff.lint.per-file-ignores]
+# Sphinx requires these exact variable names in its config module.
+"docs/conf.py" = ["A001"]
+
 [tool.ruff.lint.pylint]
 max-args = 10
 

--- a/src/solaredge/monitoring.py
+++ b/src/solaredge/monitoring.py
@@ -14,7 +14,7 @@ DEFAULT_BASE_URL = "https://monitoringapi.solaredge.com"
 MAX_CONCURRENT_REQUESTS = 3
 
 
-class BaseMonitoringClient(ABC):
+class BaseMonitoringClient(ABC):  # noqa: B024 - shared helpers, not an interface
     """Shared helpers for monitoring clients.
 
     Contains URL building, default params and simple timeout parsing. Concrete
@@ -172,10 +172,9 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         ]
         | None = None,
         sort_order: Literal["ASC", "DESC"] = "ASC",
-        status: list[Literal["Active", "Pending", "Disabled"]] | Literal["All"] = [
-            "Active",
-            "Pending",
-        ],
+        status: list[Literal["Active", "Pending", "Disabled"]]
+        | Literal["All"]
+        | None = None,
     ) -> dict:
         """Return a paginated list of sites for the account (async).
 
@@ -186,8 +185,11 @@ class AsyncMonitoringClient(BaseMonitoringClient):
                 search in: Name, Notes, Email, Country, State, City, Zip, Full address
             sort_property: Property to sort by
             sort_order: Sort order ("ASC" or "DESC")
-            status: Site status filter ("Active,Pending" by default)
+            status: Site status filter (["Active", "Pending"] by default)
         """
+        if status is None:
+            status = ["Active", "Pending"]
+
         path = "sites/list"
         params = {
             "size": size,
@@ -413,7 +415,7 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         name: str | None = None,
         max_width: int | None = None,
         max_height: int | None = None,
-        hash: int | None = None,
+        hash: int | None = None,  # noqa: A002 - mirrors the API's parameter name
     ) -> bytes:
         """Return the site image (async)."""
         if name is None:
@@ -719,10 +721,9 @@ class MonitoringClient(BaseMonitoringClient):
         ]
         | None = None,
         sort_order: Literal["ASC", "DESC"] = "ASC",
-        status: list[Literal["Active", "Pending", "Disabled"]] | Literal["All"] = [
-            "Active",
-            "Pending",
-        ],
+        status: list[Literal["Active", "Pending", "Disabled"]]
+        | Literal["All"]
+        | None = None,
     ) -> dict:
         """Return a paginated list of sites for the account (sync).
 
@@ -733,8 +734,11 @@ class MonitoringClient(BaseMonitoringClient):
                 search in: Name, Notes, Email, Country, State, City, Zip, Full address
             sort_property: Property to sort by
             sort_order: Sort order ("ASC" or "DESC")
-            status: Site status filter ("Active,Pending" by default)
+            status: Site status filter (["Active", "Pending"] by default)
         """
+        if status is None:
+            status = ["Active", "Pending"]
+
         path = "sites/list"
         params = {
             "size": size,
@@ -963,7 +967,7 @@ class MonitoringClient(BaseMonitoringClient):
         name: str | None = None,
         max_width: int | None = None,
         max_height: int | None = None,
-        hash: int | None = None,
+        hash: int | None = None,  # noqa: A002 - mirrors the API's parameter name
     ) -> bytes:
         """Return the site image (async)."""
         if name is None:

--- a/src/solaredge/monitoring.py
+++ b/src/solaredge/monitoring.py
@@ -61,23 +61,19 @@ class BaseMonitoringClient(ABC):
 
         if time_unit == "_ONE_WEEK_MAX":
             if day_delta > 7:
-                raise ValueError(("The maximum date range is 1 week (7 days).",))
+                raise ValueError("The maximum date range is 1 week (7 days).")
 
         if time_unit in ("QUARTER_OF_AN_HOUR", "HOUR"):
             if day_delta > 31:
                 raise ValueError(
-                    (
-                        f"For time_unit {time_unit}, ",
-                        "the maximum date range is 1 month (31 days).",
-                    )
+                    f"For time_unit {time_unit}, "
+                    "the maximum date range is 1 month (31 days)."
                 )
         if time_unit == "DAY":
             if day_delta > 365:
                 raise ValueError(
-                    (
-                        f"For time_unit {time_unit}, ",
-                        "the maximum date range is 1 year (365 days).",
-                    )
+                    f"For time_unit {time_unit}, "
+                    "the maximum date range is 1 year (365 days)."
                 )
 
 
@@ -137,17 +133,23 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         method: str,
         path: str,
         params: dict | None = None,
+        raw: bool = False,
     ) -> Any:
+        """Perform a request and return parsed JSON, or raw bytes if `raw`.
+
+        Params whose value is None are dropped: httpx encodes them as empty
+        query values rather than omitting them.
+        """
         async with self._semaphore:  # Acquire semaphore before making request
             url = self._build_url(path)
             combined = {**self._default_params(), **(params or {})}
             response = await self.client.request(
                 method=method,
                 url=url,
-                params=combined,
+                params={k: v for k, v in combined.items() if v is not None},
             )
             response.raise_for_status()
-            return response.json()
+            return response.content if raw else response.json()
 
     async def get_site_list(
         self,
@@ -421,6 +423,7 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         return await self._make_request(
             method="GET",
             path=path,
+            raw=True,
             params={
                 "maxWidth": max_width,
                 "maxHeight": max_height,
@@ -456,6 +459,7 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         return await self._make_request(
             method="GET",
             path=path,
+            raw=True,
         )
 
     async def get_components_list(self, site_id: int) -> dict:
@@ -668,10 +672,18 @@ class MonitoringClient(BaseMonitoringClient):
             raise ValueError("Will not close externally provided httpx.Client.")
         self.client.close()
 
-    def _make_request(self, method: str, path: str, params: dict | None = None) -> Any:
-        """Perform a synchronous HTTP request and return parsed JSON.
+    def _make_request(
+        self,
+        method: str,
+        path: str,
+        params: dict | None = None,
+        raw: bool = False,
+    ) -> Any:
+        """Perform a synchronous request, returning parsed JSON or raw bytes.
 
-        This mirrors the async `_request` helper but uses a blocking httpx.Client.
+        This mirrors the async `_make_request` helper but uses a blocking
+        httpx.Client. Params whose value is None are dropped: httpx encodes
+        them as empty query values rather than omitting them.
         """
         url = self._build_url(path)
         combined = {
@@ -681,10 +693,10 @@ class MonitoringClient(BaseMonitoringClient):
         response = self.client.request(
             method=method,
             url=url,
-            params=combined,
+            params={k: v for k, v in combined.items() if v is not None},
         )
         response.raise_for_status()
-        return response.json()
+        return response.content if raw else response.json()
 
     def get_site_list(
         self,
@@ -961,6 +973,7 @@ class MonitoringClient(BaseMonitoringClient):
         return self._make_request(
             method="GET",
             path=path,
+            raw=True,
             params={
                 "maxWidth": max_width,
                 "maxHeight": max_height,
@@ -996,6 +1009,7 @@ class MonitoringClient(BaseMonitoringClient):
         return self._make_request(
             method="GET",
             path=path,
+            raw=True,
         )
 
     def get_components_list(self, site_id: int) -> dict:

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,16 +1,413 @@
 """Tests for the monitoring module."""
 
-from solaredge import MonitoringClient
+from typing import Any
+from datetime import datetime
+
+import httpx
+import pytest
+
+from solaredge import MonitoringClient, AsyncMonitoringClient
+
+API_KEY = "test_key"
+BASE = "https://monitoringapi.solaredge.com"
+
+# Within every timeframe limit (1 week, 1 month, 1 year), so a single pair of
+# dates can drive every method that validates a range.
+START = datetime(2024, 1, 1)
+END = datetime(2024, 1, 5)
+
+DATE_START = "2024-01-01"
+DATE_END = "2024-01-05"
+TIME_START = "2024-01-01 00:00:00"
+TIME_END = "2024-01-05 00:00:00"
+
+IMAGE_BYTES = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+
+# (method name, kwargs, expected path, expected query params minus api_key)
+ENDPOINTS: list[tuple[str, dict[str, Any], str, dict[str, str]]] = [
+    (
+        "get_site_list",
+        {},
+        "/sites/list",
+        {
+            "size": "100",
+            "startIndex": "0",
+            "sortOrder": "ASC",
+            "status": "Active,Pending",
+        },
+    ),
+    (
+        "get_site_list",
+        {"search_text": "farm", "sort_property": "Name", "status": "All"},
+        "/sites/list",
+        {
+            "size": "100",
+            "startIndex": "0",
+            "sortOrder": "ASC",
+            "status": "All",
+            "searchText": "farm",
+            "sortProperty": "Name",
+        },
+    ),
+    ("get_site_details", {"site_id": 1}, "/site/1/details", {}),
+    ("get_site_data", {"site_ids": [1, 2]}, "/site/1,2/dataPeriod", {}),
+    (
+        "get_energy",
+        {"site_ids": [1, 2], "start_date": START, "end_date": END},
+        "/site/1,2/energy",
+        {"startDate": DATE_START, "endDate": DATE_END, "timeUnit": "DAY"},
+    ),
+    (
+        "get_time_frame_energy",
+        {"site_ids": [1], "start_date": START, "end_date": END},
+        "/site/1/timeFrameEnergy",
+        {"startDate": DATE_START, "endDate": DATE_END, "timeUnit": "DAY"},
+    ),
+    (
+        "get_power",
+        {"site_id": 1, "start_time": START, "end_time": END},
+        "/site/1/power",
+        {"startTime": TIME_START, "endTime": TIME_END},
+    ),
+    ("get_overview", {"site_ids": [1, 2]}, "/site/1,2/overview", {}),
+    (
+        "get_power_details",
+        {"site_id": 1, "start_time": START, "end_time": END},
+        "/site/1/powerDetails",
+        {"startTime": TIME_START, "endTime": TIME_END},
+    ),
+    (
+        "get_power_details",
+        {
+            "site_id": 1,
+            "start_time": START,
+            "end_time": END,
+            "meters": ["Production", "Consumption"],
+        },
+        "/site/1/powerDetails",
+        {
+            "startTime": TIME_START,
+            "endTime": TIME_END,
+            "meters": "Production,Consumption",
+        },
+    ),
+    (
+        "get_energy_details",
+        {"site_id": 1, "start_time": START, "end_time": END},
+        "/site/1/energyDetails",
+        {"startTime": TIME_START, "endTime": TIME_END, "timeUnit": "DAY"},
+    ),
+    ("get_current_power_flow", {"site_id": 1}, "/site/1/currentPowerFlow", {}),
+    (
+        "get_storage_data",
+        {"site_id": 1, "start_time": START, "end_time": END},
+        "/site/1/storageData",
+        {"startTime": TIME_START, "endTime": TIME_END},
+    ),
+    (
+        "get_storage_data",
+        {"site_id": 1, "start_time": START, "end_time": END, "serials": ["A", "B"]},
+        "/site/1/storageData",
+        {"startTime": TIME_START, "endTime": TIME_END, "serials": "A,B"},
+    ),
+    (
+        "get_environmental_benefits",
+        {"site_id": 1},
+        "/site/1/envBenefits",
+        {},
+    ),
+    (
+        "get_environmental_benefits",
+        {"site_id": 1, "system_units": "Imperial"},
+        "/site/1/envBenefits",
+        {"systemUnits": "Imperial"},
+    ),
+    ("get_components_list", {"site_id": 1}, "/equipment/1/list", {}),
+    ("get_inventory", {"site_id": 1}, "/site/1/inventory", {}),
+    (
+        "get_inverter_technical_data",
+        {"site_id": 1, "serial_number": "SN1", "start_time": START, "end_time": END},
+        "/site/1/inverter/SN1/data",
+        {"startTime": TIME_START, "endTime": TIME_END},
+    ),
+    (
+        "get_equipment_change_log",
+        {"site_id": 1, "serial_number": "SN1"},
+        "/site/1/SN1/changeLog",
+        {},
+    ),
+    (
+        "get_account_list",
+        {},
+        "/accounts/list",
+        {"pageSize": "100", "startIndex": "0", "sortOrder": "ASC"},
+    ),
+    (
+        "get_meters",
+        {"site_id": 1, "start_time": START, "end_time": END},
+        "/site/1/meters",
+        {"startTime": TIME_START, "endTime": TIME_END, "timeUnit": "DAY"},
+    ),
+    ("get_sensor_list", {"site_id": 1}, "/equipment/1/sensors", {}),
+    (
+        "get_sensor_data",
+        {"site_id": 1, "start_date": START, "end_date": END},
+        "/equipment/1/sensors",
+        {"startTime": "2024-01-01T00:00:00", "endTime": "2024-01-05T00:00:00"},
+    ),
+    ("get_current_api_version", {}, "/version/current", {}),
+    ("get_supported_api_versions", {}, "/version/supported", {}),
+]
+
+IDS = [f"{name}-{i}" for i, (name, *_) in enumerate(ENDPOINTS)]
 
 
-def test_monitoring_client_init():
-    """Test that MonitoringClient can be instantiated."""
-    client = MonitoringClient(api_key="test_key")
-    assert client is not None
-    client.close()
+def _recording_transport(
+    requests: list[httpx.Request],
+    content: bytes | None = None,
+) -> httpx.MockTransport:
+    """Build a transport that records requests and returns a canned response."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if content is not None:
+            return httpx.Response(200, content=content)
+        return httpx.Response(200, json={"ok": True})
+
+    return httpx.MockTransport(handler)
 
 
-def test_monitoring_client_context_manager():
-    """Test MonitoringClient as a context manager."""
-    with MonitoringClient(api_key="test_key") as client:
+def _sync_client(requests: list[httpx.Request], content: bytes | None = None):
+    return MonitoringClient(
+        API_KEY, client=httpx.Client(transport=_recording_transport(requests, content))
+    )
+
+
+def _async_client(requests: list[httpx.Request], content: bytes | None = None):
+    return AsyncMonitoringClient(
+        API_KEY,
+        client=httpx.AsyncClient(transport=_recording_transport(requests, content)),
+    )
+
+
+def _assert_request(
+    request: httpx.Request, expected_path: str, expected_params: dict[str, str]
+) -> None:
+    """Assert URL, params and the absence of empty query values."""
+    assert request.url.path == expected_path
+    assert request.url.params["api_key"] == API_KEY
+
+    actual = {k: v for k, v in request.url.params.items() if k != "api_key"}
+    assert actual == expected_params
+
+    # Unset optional params must be omitted, not sent as `key=`.
+    assert not [k for k, v in request.url.params.items() if v == ""]
+
+
+class TestClientLifecycle:
+    """Construction and resource-ownership semantics."""
+
+    def test_init(self):
+        """Client can be instantiated and closed."""
+        client = MonitoringClient(api_key=API_KEY)
         assert client is not None
+        client.close()
+
+    def test_context_manager_closes_owned_client(self):
+        """An internally-created httpx.Client is closed on exit."""
+        with MonitoringClient(api_key=API_KEY) as client:
+            assert client is not None
+        assert client.client.is_closed
+
+    def test_context_manager_leaves_external_client_open(self):
+        """An externally-provided httpx.Client is not closed on exit."""
+        external = httpx.Client()
+        with MonitoringClient(api_key=API_KEY, client=external):
+            pass
+        assert not external.is_closed
+        external.close()
+
+    def test_close_refuses_external_client(self):
+        """close() refuses to close a client it does not own."""
+        external = httpx.Client()
+        client = MonitoringClient(api_key=API_KEY, client=external)
+        with pytest.raises(ValueError, match="externally provided"):
+            client.close()
+        external.close()
+
+    def test_base_url_override_and_trailing_slash(self):
+        """A custom base_url is used, with any trailing slash stripped."""
+        requests: list[httpx.Request] = []
+        client = MonitoringClient(
+            API_KEY,
+            base_url="https://example.test/api/",
+            client=httpx.Client(transport=_recording_transport(requests)),
+        )
+        client.get_site_details(site_id=1)
+        assert str(requests[0].url).startswith(
+            "https://example.test/api/site/1/details"
+        )
+
+    async def test_async_context_manager_closes_owned_client(self):
+        """The async client closes an httpx.AsyncClient it created."""
+        async with AsyncMonitoringClient(api_key=API_KEY) as client:
+            assert client is not None
+        assert client.client.is_closed
+
+    async def test_aclose_refuses_external_client(self):
+        """aclose() refuses to close a client it does not own."""
+        external = httpx.AsyncClient()
+        client = AsyncMonitoringClient(api_key=API_KEY, client=external)
+        with pytest.raises(ValueError, match="externally provided"):
+            await client.aclose()
+        await external.aclose()
+
+
+class TestEndpoints:
+    """Every endpoint builds the URL and query string the API expects."""
+
+    @pytest.mark.parametrize(("name", "kwargs", "path", "params"), ENDPOINTS, ids=IDS)
+    def test_sync_request(self, name, kwargs, path, params):
+        """The sync client requests the expected URL with the expected params."""
+        requests: list[httpx.Request] = []
+        client = _sync_client(requests)
+        result = getattr(client, name)(**kwargs)
+
+        assert len(requests) == 1
+        _assert_request(requests[0], path, params)
+        assert result == {"ok": True}
+
+    @pytest.mark.parametrize(("name", "kwargs", "path", "params"), ENDPOINTS, ids=IDS)
+    async def test_async_request(self, name, kwargs, path, params):
+        """The async client mirrors the sync client exactly."""
+        requests: list[httpx.Request] = []
+        client = _async_client(requests)
+        result = await getattr(client, name)(**kwargs)
+
+        assert len(requests) == 1
+        _assert_request(requests[0], path, params)
+        assert result == {"ok": True}
+
+    def test_sync_and_async_expose_the_same_endpoints(self):
+        """The two clients must not drift apart in API surface."""
+        public = lambda c: {  # noqa: E731
+            n for n in dir(c) if not n.startswith("_") and callable(getattr(c, n))
+        }
+        sync_only = public(MonitoringClient) - public(AsyncMonitoringClient) - {"close"}
+        async_only = (
+            public(AsyncMonitoringClient) - public(MonitoringClient) - {"aclose"}
+        )
+        assert not sync_only
+        assert not async_only
+
+
+class TestImageEndpoints:
+    """Image endpoints return raw bytes rather than parsed JSON."""
+
+    def test_sync_user_image_returns_bytes(self):
+        """get_site_user_image returns the response body untouched."""
+        requests: list[httpx.Request] = []
+        client = _sync_client(requests, content=IMAGE_BYTES)
+        result = client.get_site_user_image(site_id=1, max_width=100)
+
+        assert result == IMAGE_BYTES
+        _assert_request(requests[0], "/site/1/image", {"maxWidth": "100"})
+
+    def test_sync_user_image_with_name(self):
+        """A named image is requested from the /image/{name} path."""
+        requests: list[httpx.Request] = []
+        client = _sync_client(requests, content=IMAGE_BYTES)
+        client.get_site_user_image(site_id=1, name="front")
+        _assert_request(requests[0], "/site/1/image/front", {})
+
+    def test_sync_installer_image_returns_bytes(self):
+        """get_site_installer_image returns the response body untouched."""
+        requests: list[httpx.Request] = []
+        client = _sync_client(requests, content=IMAGE_BYTES)
+        result = client.get_site_installer_image(site_id=1)
+
+        assert result == IMAGE_BYTES
+        _assert_request(requests[0], "/site/1/installerImage", {})
+
+    async def test_async_user_image_returns_bytes(self):
+        """The async image endpoint also returns raw bytes."""
+        requests: list[httpx.Request] = []
+        client = _async_client(requests, content=IMAGE_BYTES)
+        result = await client.get_site_user_image(site_id=1)
+
+        assert result == IMAGE_BYTES
+        _assert_request(requests[0], "/site/1/image", {})
+
+    async def test_async_installer_image_returns_bytes(self):
+        """The async installer image endpoint also returns raw bytes."""
+        requests: list[httpx.Request] = []
+        client = _async_client(requests, content=IMAGE_BYTES)
+        result = await client.get_site_installer_image(site_id=1, name="logo")
+
+        assert result == IMAGE_BYTES
+        _assert_request(requests[0], "/site/1/installerImage/logo", {})
+
+
+class TestTimeframeValidation:
+    """Timeframe limits produce readable errors."""
+
+    def test_end_before_start(self):
+        """An inverted range is rejected."""
+        client = MonitoringClient(API_KEY)
+        with pytest.raises(ValueError, match=r"End date must be after start date\."):
+            client._validate_timeframe("DAY", END, START)
+
+    @pytest.mark.parametrize(
+        ("time_unit", "end", "expected"),
+        [
+            (
+                "_ONE_WEEK_MAX",
+                datetime(2024, 2, 1),
+                "The maximum date range is 1 week (7 days).",
+            ),
+            (
+                "HOUR",
+                datetime(2024, 3, 1),
+                "For time_unit HOUR, the maximum date range is 1 month (31 days).",
+            ),
+            (
+                "QUARTER_OF_AN_HOUR",
+                datetime(2024, 3, 1),
+                "For time_unit QUARTER_OF_AN_HOUR, "
+                "the maximum date range is 1 month (31 days).",
+            ),
+            (
+                "DAY",
+                datetime(2026, 1, 1),
+                "For time_unit DAY, the maximum date range is 1 year (365 days).",
+            ),
+        ],
+    )
+    def test_range_limits(self, time_unit, end, expected):
+        """Exceeding a limit raises ValueError with a plain-string message."""
+        client = MonitoringClient(API_KEY)
+        with pytest.raises(ValueError) as excinfo:
+            client._validate_timeframe(time_unit, START, end)
+
+        # A tuple-wrapped message would render as "('...', '...')".
+        assert str(excinfo.value) == expected
+
+    def test_endpoint_propagates_validation_error(self):
+        """Validation runs before any request is made."""
+        requests: list[httpx.Request] = []
+        client = _sync_client(requests)
+        with pytest.raises(ValueError):
+            client.get_storage_data(
+                site_id=1, start_time=START, end_time=datetime(2024, 2, 1)
+            )
+        assert requests == []
+
+
+class TestSiteLimits:
+    """Documented request-size limits."""
+
+    def test_site_data_rejects_more_than_100_sites(self):
+        """get_site_data enforces the 100-site cap."""
+        client = MonitoringClient(API_KEY)
+        with pytest.raises(ValueError, match="more than 100 sites"):
+            client.get_site_data(site_ids=list(range(101)))


### PR DESCRIPTION
Addresses the correctness and tooling findings from the repo review. Closes #96, #97, #98, #100, #102, #103.

## Correctness fixes

Each is covered by a test that fails without its fix — verified by reverting the fixes and confirming 11 tests go red.

**Image endpoints returned nothing usable (#96).** `get_site_user_image` and `get_site_installer_image` are annotated `-> bytes` but routed through `_make_request`, which always called `response.json()`. Any real image response raised `UnicodeDecodeError`, so all four methods (sync + async) could never have worked. `_make_request` now takes `raw` and returns `response.content`.

**Unset optional params were transmitted as empty values (#98).** httpx encodes `None` as `''` rather than omitting the key, so `get_site_user_image(site_id=1, max_width=100)` requested `/site/1/image?maxWidth=100&maxHeight=&hash=`. `_make_request` now strips `None` centrally, fixing every affected method at once rather than call site by call site.

**Timeframe errors rendered as tuple reprs (#97).** Stray trailing commas made three `ValueError` messages tuples: `('For time_unit HOUR, ', 'the maximum date range is 1 month (31 days).')`. Now plain strings.

## Test suite (#100)

Coverage goes from **31% to 96%** (198 uncovered statements down to 7). Previously no test called any of the 24 API methods; the two existing tests only checked that the constructor returned non-`None`.

Uses `httpx.MockTransport` through the clients' existing `client=` argument — no network, and `pytest-asyncio` is the only new dependency. A table-driven parametrization covers all 24 endpoints on **both** clients, asserting requested path, exact query parameters, and return type. Also covers timeframe validation boundaries and message text, client lifecycle and ownership semantics (owned clients closed, external clients left open), and sync/async API parity so the two classes can't silently drift.

One assertion worth calling out: `_assert_request` fails if *any* query parameter is empty, which makes #98 impossible to reintroduce anywhere, including in endpoints added later.

## Tooling

**`py.typed` (#102).** The package is fully annotated but shipped no PEP 561 marker, so type checkers treated it as untyped and downstream consumers got `Any` for the whole library. Confirmed present in the built wheel.

**Ruff rule selection (#103).** The `select` comments labelled `F` as bugbear and `E` as pyflakes, and bugbear was never actually enabled. Corrected the labels, added `B` and `A`, and resolved what they surfaced:

- `B006` — `get_site_list` took a mutable list default for `status`; now `None` with the default resolved in the body. Existing calls are unaffected.
- `A002` — the `hash` parameter mirrors the upstream API's query parameter name, so it carries a `noqa` rather than being renamed; renaming would break keyword callers of a published package.
- `B024` — `BaseMonitoringClient` subclasses `ABC` but declares no abstract methods. Annotated rather than restructured, since the class layout is the subject of #101.
- `A001` — Sphinx mandates the `copyright` name in `conf.py`, so that file carries a per-file ignore.

## Not included

- **#99** (`get_sensor_data` and `get_sensor_list` build the same URL) needs confirmation against the live SolarEdge spec before changing a request path; the bundled docs hedge on paths. The current behaviour is pinned by a test so the fix will be a visible one-line diff.
- **#101** (sync/async duplication) and **#104**/**#105** are left as follow-ups. The refactor is much safer to attempt now that there's a suite to hold it in place.

## Testing

- `uv run pytest` — 72 passed
- `uv run pytest --cov` — 96%
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run pre-commit run --all-files` — all hooks pass
- `uv build` + wheel inspection — `py.typed` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8)_