### PR TITLE
refactor(monitoring): extract shared endpoint layer

### DIFF
--- a/src/solaredge/_endpoints.py
+++ b/src/solaredge/_endpoints.py
@@ -1,0 +1,412 @@
+"""Endpoint definitions shared by the synchronous and asynchronous clients.
+
+Every builder here is a pure function: it validates its arguments, assembles
+the request path and query parameters, and returns a :class:`Request`. No I/O
+happens in this module, so both clients share a single definition of each
+endpoint and can be thin transport wrappers around it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, NamedTuple
+from datetime import datetime
+from collections.abc import Iterable
+
+# Shared vocabulary for the API's enumerated values. Defined once here and
+# reused in both clients' public signatures.
+TimeUnit = Literal["QUARTER_OF_AN_HOUR", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"]
+SortOrder = Literal["ASC", "DESC"]
+SiteStatus = Literal["Active", "Pending", "Disabled"]
+SystemUnits = Literal["Metrics", "Imperial"]
+Meter = Literal[
+    "Production",
+    "Consumption",
+    "SelfConsumption",
+    "FeedIn",
+    "Purchased",
+]
+MeterReading = Literal["Production", "Consumption", "FeedIn", "Purchased"]
+SiteSortProperty = Literal[
+    "Name",
+    "Country",
+    "State",
+    "City",
+    "Address",
+    "Zip",
+    "Status",
+    "PeakPower",
+    "InstallationDate",
+    "Amount",
+    "MaxSeverity",
+    "CreationTime",
+]
+AccountSortProperty = Literal[
+    "Name",
+    "country",
+    "city",
+    "address",
+    "zip",
+    "fax",
+    "phone",
+    "notes",
+]
+
+# `_ONE_WEEK_MAX` is not an API time unit; it selects the one-week ceiling for
+# endpoints that impose one without taking a timeUnit parameter.
+ValidatedTimeUnit = Literal[
+    "QUARTER_OF_AN_HOUR",
+    "HOUR",
+    "DAY",
+    "_ONE_WEEK_MAX",
+    "WEEK",
+    "MONTH",
+    "YEAR",
+]
+
+MAX_SITES_PER_REQUEST = 100
+MAX_PAGE_SIZE = 100
+
+_DATE_FORMAT = "%Y-%m-%d"
+_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+
+class Request(NamedTuple):
+    """A fully-described API request, independent of how it is sent."""
+
+    method: str
+    path: str
+    params: dict[str, Any] | None = None
+    raw: bool = False
+
+
+def validate_timeframe(
+    time_unit: ValidatedTimeUnit,
+    start_date: datetime,
+    end_date: datetime,
+) -> None:
+    """Validate a requested time frame against the API's documented limits.
+
+    Raises:
+        ValueError: If the range is inverted or exceeds the limit for the unit.
+    """
+    day_delta = (end_date - start_date).days
+
+    if day_delta < 0:
+        raise ValueError("End date must be after start date.")
+
+    if time_unit == "_ONE_WEEK_MAX":
+        if day_delta > 7:
+            raise ValueError("The maximum date range is 1 week (7 days).")
+
+    if time_unit in ("QUARTER_OF_AN_HOUR", "HOUR"):
+        if day_delta > 31:
+            raise ValueError(
+                f"For time_unit {time_unit}, "
+                "the maximum date range is 1 month (31 days)."
+            )
+    if time_unit == "DAY":
+        if day_delta > 365:
+            raise ValueError(
+                f"For time_unit {time_unit}, "
+                "the maximum date range is 1 year (365 days)."
+            )
+
+
+def _site_ids(site_ids: Iterable[int]) -> str:
+    """Render a collection of site IDs as the API's comma-separated form."""
+    return ",".join(map(str, site_ids))
+
+
+def site_list(
+    size: int,
+    start_index: int,
+    search_text: str | None,
+    sort_property: SiteSortProperty | None,
+    sort_order: SortOrder,
+    status: list[SiteStatus] | Literal["All"] | None,
+) -> Request:
+    """Build the request for a paginated list of sites."""
+    if status is None:
+        status = ["Active", "Pending"]
+
+    params: dict[str, Any] = {
+        "size": size,
+        "startIndex": start_index,
+        "sortOrder": sort_order,
+        "status": status if status == "All" else ",".join(status),
+    }
+    if search_text:
+        params["searchText"] = search_text
+    if sort_property:
+        params["sortProperty"] = sort_property
+    return Request("GET", "sites/list", params)
+
+
+def site_details(site_id: int) -> Request:
+    """Build the request for a single site's details."""
+    return Request("GET", f"site/{site_id}/details")
+
+
+def site_data(site_ids: list[int]) -> Request:
+    """Build the request for the sites' energy data period."""
+    if len(site_ids) > MAX_SITES_PER_REQUEST:
+        raise ValueError("Cannot request data for more than 100 sites at once.")
+    return Request("GET", f"site/{_site_ids(site_ids)}/dataPeriod")
+
+
+def energy(
+    site_ids: list[int],
+    start_date: datetime,
+    end_date: datetime,
+    time_unit: TimeUnit,
+) -> Request:
+    """Build the request for aggregated site energy."""
+    validate_timeframe(time_unit, start_date, end_date)
+    return Request(
+        "GET",
+        f"site/{_site_ids(site_ids)}/energy",
+        {
+            "startDate": start_date.strftime(_DATE_FORMAT),
+            "endDate": end_date.strftime(_DATE_FORMAT),
+            "timeUnit": time_unit,
+        },
+    )
+
+
+def time_frame_energy(
+    site_ids: list[int],
+    start_date: datetime,
+    end_date: datetime,
+    time_unit: TimeUnit,
+) -> Request:
+    """Build the request for on-grid energy over a time frame."""
+    validate_timeframe(time_unit, start_date, end_date)
+    return Request(
+        "GET",
+        f"site/{_site_ids(site_ids)}/timeFrameEnergy",
+        {
+            "startDate": start_date.strftime(_DATE_FORMAT),
+            "endDate": end_date.strftime(_DATE_FORMAT),
+            "timeUnit": time_unit,
+        },
+    )
+
+
+def power(site_id: int, start_time: datetime, end_time: datetime) -> Request:
+    """Build the request for 15-minute-resolution power measurements."""
+    validate_timeframe("QUARTER_OF_AN_HOUR", start_time, end_time)
+    return Request(
+        "GET",
+        f"site/{site_id}/power",
+        {
+            "startTime": start_time.strftime(_DATETIME_FORMAT),
+            "endTime": end_time.strftime(_DATETIME_FORMAT),
+        },
+    )
+
+
+def overview(site_ids: list[int]) -> Request:
+    """Build the request for a site overview."""
+    return Request("GET", f"site/{_site_ids(site_ids)}/overview")
+
+
+def power_details(
+    site_id: int,
+    start_time: datetime,
+    end_time: datetime,
+    meters: Iterable[Meter] | None,
+) -> Request:
+    """Build the request for detailed power measurements."""
+    validate_timeframe("QUARTER_OF_AN_HOUR", start_time, end_time)
+    params: dict[str, Any] = {
+        "startTime": start_time.strftime(_DATETIME_FORMAT),
+        "endTime": end_time.strftime(_DATETIME_FORMAT),
+    }
+    if meters:
+        params["meters"] = ",".join(meters)
+    return Request("GET", f"site/{site_id}/powerDetails", params)
+
+
+def energy_details(
+    site_id: int,
+    start_time: datetime,
+    end_time: datetime,
+    meters: Iterable[Meter] | None,
+    time_unit: TimeUnit,
+) -> Request:
+    """Build the request for a detailed energy breakdown."""
+    validate_timeframe(time_unit, start_time, end_time)
+    params: dict[str, Any] = {
+        "startTime": start_time.strftime(_DATETIME_FORMAT),
+        "endTime": end_time.strftime(_DATETIME_FORMAT),
+        "timeUnit": time_unit,
+    }
+    if meters:
+        params["meters"] = ",".join(meters)
+    return Request("GET", f"site/{site_id}/energyDetails", params)
+
+
+def current_power_flow(site_id: int) -> Request:
+    """Build the request for the site's current power flow."""
+    return Request("GET", f"site/{site_id}/currentPowerFlow")
+
+
+def storage_data(
+    site_id: int,
+    start_time: datetime,
+    end_time: datetime,
+    serials: Iterable[str] | None,
+) -> Request:
+    """Build the request for battery measurements."""
+    validate_timeframe("_ONE_WEEK_MAX", start_time, end_time)
+    params: dict[str, Any] = {
+        "startTime": start_time.strftime(_DATETIME_FORMAT),
+        "endTime": end_time.strftime(_DATETIME_FORMAT),
+    }
+    if serials:
+        params["serials"] = ",".join(serials)
+    return Request("GET", f"site/{site_id}/storageData", params)
+
+
+def site_user_image(
+    site_id: int,
+    name: str | None,
+    max_width: int | None,
+    max_height: int | None,
+    image_hash: int | None,
+) -> Request:
+    """Build the request for the site image, which returns raw bytes."""
+    path = f"site/{site_id}/image" if name is None else f"site/{site_id}/image/{name}"
+    return Request(
+        "GET",
+        path,
+        {
+            "maxWidth": max_width,
+            "maxHeight": max_height,
+            "hash": image_hash,
+        },
+        raw=True,
+    )
+
+
+def environmental_benefits(site_id: int, system_units: SystemUnits | None) -> Request:
+    """Build the request for the site's environmental benefits."""
+    return Request(
+        "GET",
+        f"site/{site_id}/envBenefits",
+        {"systemUnits": system_units},
+    )
+
+
+def site_installer_image(site_id: int, name: str | None) -> Request:
+    """Build the request for the installer image, which returns raw bytes."""
+    path = (
+        f"site/{site_id}/installerImage"
+        if name is None
+        else f"site/{site_id}/installerImage/{name}"
+    )
+    return Request("GET", path, raw=True)
+
+
+def components_list(site_id: int) -> Request:
+    """Build the request for the site's inverters and SMIs."""
+    return Request("GET", f"equipment/{site_id}/list")
+
+
+def inventory(site_id: int) -> Request:
+    """Build the request for the site's equipment inventory."""
+    return Request("GET", f"site/{site_id}/inventory")
+
+
+def inverter_technical_data(
+    site_id: int,
+    serial_number: str,
+    start_time: datetime,
+    end_time: datetime,
+) -> Request:
+    """Build the request for a single inverter's technical data."""
+    validate_timeframe("_ONE_WEEK_MAX", start_time, end_time)
+    return Request(
+        "GET",
+        f"site/{site_id}/inverter/{serial_number}/data",
+        {
+            "startTime": start_time.strftime(_DATETIME_FORMAT),
+            "endTime": end_time.strftime(_DATETIME_FORMAT),
+        },
+    )
+
+
+def equipment_change_log(site_id: int, serial_number: str) -> Request:
+    """Build the request for a component's replacement history."""
+    return Request("GET", f"site/{site_id}/{serial_number}/changeLog")
+
+
+def account_list(
+    page_size: int,
+    start_index: int,
+    search_text: str | None,
+    sort_property: AccountSortProperty | None,
+    sort_order: SortOrder,
+) -> Request:
+    """Build the request for the account and its sub-accounts."""
+    return Request(
+        "GET",
+        "accounts/list",
+        {
+            "pageSize": min(page_size, MAX_PAGE_SIZE),
+            "startIndex": start_index,
+            "searchText": search_text,
+            "sortProperty": sort_property,
+            "sortOrder": sort_order,
+        },
+    )
+
+
+def meters(
+    site_id: int,
+    start_time: datetime,
+    end_time: datetime,
+    time_unit: TimeUnit,
+    meters: Iterable[MeterReading] | None,
+) -> Request:
+    """Build the request for the site's meters and their readings."""
+    validate_timeframe(time_unit, start_time, end_time)
+    return Request(
+        "GET",
+        f"site/{site_id}/meters",
+        {
+            "startTime": start_time.strftime(_DATETIME_FORMAT),
+            "endTime": end_time.strftime(_DATETIME_FORMAT),
+            "timeUnit": time_unit,
+            "meters": ",".join(meters) if meters else None,
+        },
+    )
+
+
+def sensor_list(site_id: int) -> Request:
+    """Build the request for the site's sensors."""
+    return Request("GET", f"equipment/{site_id}/sensors")
+
+
+def sensor_data(site_id: int, start_date: datetime, end_date: datetime) -> Request:
+    """Build the request for sensor measurements."""
+    validate_timeframe("_ONE_WEEK_MAX", start_date, end_date)
+    return Request(
+        "GET",
+        f"equipment/{site_id}/sensors",
+        {
+            "startTime": start_date.strftime(_ISO_FORMAT),
+            "endTime": end_date.strftime(_ISO_FORMAT),
+        },
+    )
+
+
+def current_api_version() -> Request:
+    """Build the request for the current API version."""
+    return Request("GET", "version/current")
+
+
+def supported_api_versions() -> Request:
+    """Build the request for the list of supported API versions."""
+    return Request("GET", "version/supported")

--- a/src/solaredge/monitoring.py
+++ b/src/solaredge/monitoring.py
@@ -10,6 +10,20 @@ from collections.abc import Iterable
 
 import httpx
 
+from . import _endpoints
+from ._endpoints import (
+    Meter,
+    Request,
+    TimeUnit,
+    SortOrder,
+    SiteStatus,
+    SystemUnits,
+    MeterReading,
+    SiteSortProperty,
+    ValidatedTimeUnit,
+    AccountSortProperty,
+)
+
 DEFAULT_BASE_URL = "https://monitoringapi.solaredge.com"
 MAX_CONCURRENT_REQUESTS = 3
 
@@ -17,8 +31,9 @@ MAX_CONCURRENT_REQUESTS = 3
 class BaseMonitoringClient(ABC):  # noqa: B024 - shared helpers, not an interface
     """Shared helpers for monitoring clients.
 
-    Contains URL building, default params and simple timeout parsing. Concrete
-    clients (sync/async) should inherit this to reuse utilities.
+    Holds URL building, default params, timeout parsing and the request/response
+    plumbing that does not depend on whether I/O is blocking. Concrete clients
+    (sync/async) inherit this and supply only the transport.
     """
 
     def __init__(self, api_key: str, base_url: str | None = None):
@@ -38,15 +53,7 @@ class BaseMonitoringClient(ABC):  # noqa: B024 - shared helpers, not an interfac
 
     def _validate_timeframe(
         self,
-        time_unit: Literal[
-            "QUARTER_OF_AN_HOUR",
-            "HOUR",
-            "DAY",
-            "_ONE_WEEK_MAX",
-            "WEEK",
-            "MONTH",
-            "YEAR",
-        ],
+        time_unit: ValidatedTimeUnit,
         start_date: datetime,
         end_date: datetime,
     ) -> None:
@@ -54,27 +61,23 @@ class BaseMonitoringClient(ABC):  # noqa: B024 - shared helpers, not an interfac
 
         throws an error or returns None.
         """
-        day_delta = (end_date - start_date).days
+        _endpoints.validate_timeframe(time_unit, start_date, end_date)
 
-        if day_delta < 0:
-            raise ValueError("End date must be after start date.")
+    def _prepare(self, request: Request) -> tuple[str, dict[str, Any]]:
+        """Resolve a Request into the URL and query params to send.
 
-        if time_unit == "_ONE_WEEK_MAX":
-            if day_delta > 7:
-                raise ValueError("The maximum date range is 1 week (7 days).")
+        Params whose value is None are dropped: httpx encodes them as empty
+        query values rather than omitting them.
+        """
+        url = self._build_url(request.path)
+        combined = {**self._default_params(), **(request.params or {})}
+        return url, {k: v for k, v in combined.items() if v is not None}
 
-        if time_unit in ("QUARTER_OF_AN_HOUR", "HOUR"):
-            if day_delta > 31:
-                raise ValueError(
-                    f"For time_unit {time_unit}, "
-                    "the maximum date range is 1 month (31 days)."
-                )
-        if time_unit == "DAY":
-            if day_delta > 365:
-                raise ValueError(
-                    f"For time_unit {time_unit}, "
-                    "the maximum date range is 1 year (365 days)."
-                )
+    @staticmethod
+    def _parse_response(response: httpx.Response, raw: bool) -> Any:
+        """Raise for error status, then return raw bytes or parsed JSON."""
+        response.raise_for_status()
+        return response.content if raw else response.json()
 
 
 class AsyncMonitoringClient(BaseMonitoringClient):
@@ -128,53 +131,25 @@ class AsyncMonitoringClient(BaseMonitoringClient):
             raise ValueError("Will not close externally provided httpx.Client.")
         await self.client.aclose()
 
-    async def _make_request(
-        self,
-        method: str,
-        path: str,
-        params: dict | None = None,
-        raw: bool = False,
-    ) -> Any:
-        """Perform a request and return parsed JSON, or raw bytes if `raw`.
-
-        Params whose value is None are dropped: httpx encodes them as empty
-        query values rather than omitting them.
-        """
+    async def _send(self, request: Request) -> Any:
+        """Send a prepared request, respecting the concurrency limit."""
         async with self._semaphore:  # Acquire semaphore before making request
-            url = self._build_url(path)
-            combined = {**self._default_params(), **(params or {})}
+            url, params = self._prepare(request)
             response = await self.client.request(
-                method=method,
+                method=request.method,
                 url=url,
-                params={k: v for k, v in combined.items() if v is not None},
+                params=params,
             )
-            response.raise_for_status()
-            return response.content if raw else response.json()
+            return self._parse_response(response, request.raw)
 
     async def get_site_list(
         self,
         size: int = 100,
         start_index: int = 0,
         search_text: str | None = None,
-        sort_property: Literal[
-            "Name",
-            "Country",
-            "State",
-            "City",
-            "Address",
-            "Zip",
-            "Status",
-            "PeakPower",
-            "InstallationDate",
-            "Amount",
-            "MaxSeverity",
-            "CreationTime",
-        ]
-        | None = None,
-        sort_order: Literal["ASC", "DESC"] = "ASC",
-        status: list[Literal["Active", "Pending", "Disabled"]]
-        | Literal["All"]
-        | None = None,
+        sort_property: SiteSortProperty | None = None,
+        sort_order: SortOrder = "ASC",
+        status: list[SiteStatus] | Literal["All"] | None = None,
     ) -> dict:
         """Return a paginated list of sites for the account (async).
 
@@ -187,70 +162,34 @@ class AsyncMonitoringClient(BaseMonitoringClient):
             sort_order: Sort order ("ASC" or "DESC")
             status: Site status filter (["Active", "Pending"] by default)
         """
-        if status is None:
-            status = ["Active", "Pending"]
-
-        path = "sites/list"
-        params = {
-            "size": size,
-            "startIndex": start_index,
-            "sortOrder": sort_order,
-            "status": status if status == "All" else ",".join(status),
-        }
-        if search_text:
-            params["searchText"] = search_text
-        if sort_property:
-            params["sortProperty"] = sort_property
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return await self._send(
+            _endpoints.site_list(
+                size, start_index, search_text, sort_property, sort_order, status
+            )
         )
 
     async def get_site_details(self, site_id: int) -> dict:
         """Get site details (async)."""
-        path = f"site/{site_id}/details"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.site_details(site_id))
 
     async def get_site_data(self, site_ids: list[int]) -> dict:
         """Return the site's energy data period (start/end) (async)."""
-        if len(site_ids) > 100:
-            raise ValueError("Cannot request data for more than 100 sites at once.")
-        path = f"site/{','.join(map(str, site_ids))}/dataPeriod"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.site_data(site_ids))
 
     async def get_energy(
         self,
         site_ids: list[int],
         start_date: datetime,
         end_date: datetime,
-        time_unit: Literal[
-            "QUARTER_OF_AN_HOUR", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"
-        ] = "DAY",
+        time_unit: TimeUnit = "DAY",
     ) -> dict:
         """Get aggregated energy for a site between two dates (async).
 
         this endpoint returns the same energy measurements
         that appear in the Site Dashboard.
         """
-        self._validate_timeframe(time_unit, start_date, end_date)
-
-        path = f"site/{','.join(map(str, site_ids))}/energy"
-        params = {
-            "startDate": start_date.strftime("%Y-%m-%d"),
-            "endDate": end_date.strftime("%Y-%m-%d"),
-            "timeUnit": time_unit,
-        }
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return await self._send(
+            _endpoints.energy(site_ids, start_date, end_date, time_unit)
         )
 
     async def get_time_frame_energy(
@@ -258,9 +197,7 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         site_ids: list[int],
         start_date: datetime,
         end_date: datetime,
-        time_unit: Literal[
-            "QUARTER_OF_AN_HOUR", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"
-        ] = "DAY",
+        time_unit: TimeUnit = "DAY",
     ) -> dict:
         """Get time-frame energy (async).
 
@@ -268,18 +205,8 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         In sites with storage/backup, this may mean that results can differ from what appears in the Site Dashboard.
         Use the regular Site Energy API to obtain results that match the Site Dashboard calculation.
         """  # noqa: E501
-        self._validate_timeframe(time_unit, start_date, end_date)
-
-        path = f"site/{','.join(map(str, site_ids))}/timeFrameEnergy"
-        params = {
-            "startDate": start_date.strftime("%Y-%m-%d"),
-            "endDate": end_date.strftime("%Y-%m-%d"),
-            "timeUnit": time_unit,
-        }
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return await self._send(
+            _endpoints.time_frame_energy(site_ids, start_date, end_date, time_unit)
         )
 
     async def get_power(
@@ -289,57 +216,22 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         end_time: datetime,
     ) -> dict:
         """Return power measurements (15-minute resolution) for a timeframe (async)."""
-        self._validate_timeframe("QUARTER_OF_AN_HOUR", start_time, end_time)
-
-        path = f"site/{site_id}/power"
-        params = {
-            "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-        }
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params=params,
-        )
+        return await self._send(_endpoints.power(site_id, start_time, end_time))
 
     async def get_overview(self, site_ids: list[int]) -> dict:
         """Return a site overview (async)."""
-        path = f"site/{','.join(map(str, site_ids))}/overview"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.overview(site_ids))
 
     async def get_power_details(
         self,
         site_id: int,
         start_time: datetime,
         end_time: datetime,
-        meters: Iterable[
-            Literal[
-                "Production",
-                "Consumption",
-                "SelfConsumption",
-                "FeedIn",
-                "Purchased",
-            ]
-        ]
-        | None = None,
+        meters: Iterable[Meter] | None = None,
     ) -> dict:
         """Return detailed power measurements including optional meters (async)."""
-        self._validate_timeframe("QUARTER_OF_AN_HOUR", start_time, end_time)
-
-        path = f"site/{site_id}/powerDetails"
-        params = {
-            "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-        }
-        if meters:
-            params["meters"] = ",".join(meters)
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return await self._send(
+            _endpoints.power_details(site_id, start_time, end_time, meters)
         )
 
     async def get_energy_details(
@@ -347,44 +239,17 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         site_id: int,
         start_time: datetime,
         end_time: datetime,
-        meters: Iterable[
-            Literal[
-                "Production",
-                "Consumption",
-                "SelfConsumption",
-                "FeedIn",
-                "Purchased",
-            ]
-        ]
-        | None = None,
-        time_unit: Literal[
-            "QUARTER_OF_AN_HOUR", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"
-        ] = "DAY",
+        meters: Iterable[Meter] | None = None,
+        time_unit: TimeUnit = "DAY",
     ) -> dict:
         """Return detailed energy breakdown (by meter/timeUnit) (async)."""
-        self._validate_timeframe(time_unit, start_time, end_time)
-
-        path = f"site/{site_id}/energyDetails"
-        params = {
-            "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "timeUnit": time_unit,
-        }
-        if meters:
-            params["meters"] = ",".join(meters)
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return await self._send(
+            _endpoints.energy_details(site_id, start_time, end_time, meters, time_unit)
         )
 
     async def get_current_power_flow(self, site_id: int) -> dict:
         """Return the current power flow (async)."""
-        path = f"site/{site_id}/currentPowerFlow"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.current_power_flow(site_id))
 
     async def get_storage_data(
         self,
@@ -394,19 +259,8 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         serials: Iterable[str] | None = None,
     ) -> dict:
         """Return storage (battery) measurements for the timeframe (async)."""
-        self._validate_timeframe("_ONE_WEEK_MAX", start_time, end_time)
-
-        path = f"site/{site_id}/storageData"
-        params = {
-            "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-        }
-        if serials:
-            params["serials"] = ",".join(serials)
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return await self._send(
+            _endpoints.storage_data(site_id, start_time, end_time, serials)
         )
 
     async def get_site_user_image(
@@ -418,34 +272,18 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         hash: int | None = None,  # noqa: A002 - mirrors the API's parameter name
     ) -> bytes:
         """Return the site image (async)."""
-        if name is None:
-            path = f"site/{site_id}/image"
-        else:
-            path = f"site/{site_id}/image/{name}"
-        return await self._make_request(
-            method="GET",
-            path=path,
-            raw=True,
-            params={
-                "maxWidth": max_width,
-                "maxHeight": max_height,
-                "hash": hash,
-            },
+        return await self._send(
+            _endpoints.site_user_image(site_id, name, max_width, max_height, hash)
         )
 
     async def get_environmental_benefits(
         self,
         site_id: int,
-        system_units: Literal["Metrics", "Imperial"] | None = None,
+        system_units: SystemUnits | None = None,
     ) -> dict:
         """Return the environmental benefits (async)."""
-        path = f"site/{site_id}/envBenefits"
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "systemUnits": system_units,
-            },
+        return await self._send(
+            _endpoints.environmental_benefits(site_id, system_units)
         )
 
     async def get_site_installer_image(
@@ -454,34 +292,18 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         name: str | None = None,
     ) -> bytes:
         """Return the site installer image (async)."""
-        if name is None:
-            path = f"site/{site_id}/installerImage"
-        else:
-            path = f"site/{site_id}/installerImage/{name}"
-        return await self._make_request(
-            method="GET",
-            path=path,
-            raw=True,
-        )
+        return await self._send(_endpoints.site_installer_image(site_id, name))
 
     async def get_components_list(self, site_id: int) -> dict:
         """Return a list of inverters/SMIs in the specific site. (async)."""
-        path = f"equipment/{site_id}/list"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.components_list(site_id))
 
     async def get_inventory(self, site_id: int) -> dict:
         """Return the inventory of SolarEdge equipment in the site (async).
 
         Including inverters/SMIs, batteries, meters, gateways and sensors.
         """
-        path = f"site/{site_id}/inventory"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.inventory(site_id))
 
     async def get_inverter_technical_data(
         self,
@@ -491,15 +313,10 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         end_time: datetime,
     ) -> dict:
         """Return specific inverter data for a given timeframe (async)."""
-        self._validate_timeframe("_ONE_WEEK_MAX", start_time, end_time)
-        path = f"site/{site_id}/inverter/{serial_number}/data"
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-                "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-            },
+        return await self._send(
+            _endpoints.inverter_technical_data(
+                site_id, serial_number, start_time, end_time
+            )
         )
 
     async def get_equipment_change_log(
@@ -511,42 +328,21 @@ class AsyncMonitoringClient(BaseMonitoringClient):
 
         This method is applicable to inverters, optimizers, batteries and gateways.
         """
-        path = f"site/{site_id}/{serial_number}/changeLog"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.equipment_change_log(site_id, serial_number))
 
     async def get_account_list(
         self,
         page_size: int = 100,
         start_index: int = 0,
         search_text: str | None = None,
-        sort_property: Literal[
-            "Name",
-            "country",
-            "city",
-            "address",
-            "zip",
-            "fax",
-            "phone",
-            "notes",
-        ]
-        | None = None,
-        sort_order: Literal["ASC", "DESC"] = "ASC",
+        sort_property: AccountSortProperty | None = None,
+        sort_order: SortOrder = "ASC",
     ) -> dict:
         """Return the account and list of sub-accounts (async)."""
-        path = "accounts/list"
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "pageSize": min(page_size, 100),
-                "startIndex": start_index,
-                "searchText": search_text,
-                "sortProperty": sort_property,
-                "sortOrder": sort_order,
-            },
+        return await self._send(
+            _endpoints.account_list(
+                page_size, start_index, search_text, sort_property, sort_order
+            )
         )
 
     async def get_meters(
@@ -554,44 +350,21 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         site_id: int,
         start_time: datetime,
         end_time: datetime,
-        time_unit: Literal[
-            "QUARTER_OF_AN_HOUR", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"
-        ] = "DAY",
-        meters: Iterable[
-            Literal[
-                "Production",
-                "Consumption",
-                "FeedIn",
-                "Purchased",
-            ]
-        ]
-        | None = None,
+        time_unit: TimeUnit = "DAY",
+        meters: Iterable[MeterReading] | None = None,
     ) -> dict:
         """Return a list of meters in the specific site. (async).
 
         Returns for each meter on site its lifetime energy reading,
         metadata and the device to which it's connected to.
         """
-        self._validate_timeframe(time_unit, start_time, end_time)
-        path = f"site/{site_id}/meters"
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-                "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-                "timeUnit": time_unit,
-                "meters": ",".join(meters) if meters else None,
-            },
+        return await self._send(
+            _endpoints.meters(site_id, start_time, end_time, time_unit, meters)
         )
 
     async def get_sensor_list(self, site_id: int) -> dict:
         """Returns a list of all the sensors in the site, and the device to which they are connected.  (async)."""  # noqa: E501
-        path = f"equipment/{site_id}/sensors"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.sensor_list(site_id))
 
     async def get_sensor_data(
         self,
@@ -600,32 +373,15 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         end_date: datetime,
     ) -> dict:
         """Returns the data of all the sensors in the site, by the gateway they are connected to. (async)."""  # noqa: E501
-        self._validate_timeframe("_ONE_WEEK_MAX", start_date, end_date)
-        path = f"equipment/{site_id}/sensors"
-        return await self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "startTime": start_date.strftime("%Y-%m-%dT%H:%M:%S"),
-                "endTime": end_date.strftime("%Y-%m-%dT%H:%M:%S"),
-            },
-        )
+        return await self._send(_endpoints.sensor_data(site_id, start_date, end_date))
 
     async def get_current_api_version(self) -> dict:
         """Returns the current API version. (async)."""
-        path = "version/current"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.current_api_version())
 
     async def get_supported_api_versions(self) -> dict:
         """Returns a list of supported API versions. (async)."""
-        path = "version/supported"
-        return await self._make_request(
-            method="GET",
-            path=path,
-        )
+        return await self._send(_endpoints.supported_api_versions())
 
 
 class MonitoringClient(BaseMonitoringClient):
@@ -674,56 +430,24 @@ class MonitoringClient(BaseMonitoringClient):
             raise ValueError("Will not close externally provided httpx.Client.")
         self.client.close()
 
-    def _make_request(
-        self,
-        method: str,
-        path: str,
-        params: dict | None = None,
-        raw: bool = False,
-    ) -> Any:
-        """Perform a synchronous request, returning parsed JSON or raw bytes.
-
-        This mirrors the async `_make_request` helper but uses a blocking
-        httpx.Client. Params whose value is None are dropped: httpx encodes
-        them as empty query values rather than omitting them.
-        """
-        url = self._build_url(path)
-        combined = {
-            **self._default_params(),
-            **(params or {}),
-        }
+    def _send(self, request: Request) -> Any:
+        """Send a prepared request using the blocking client."""
+        url, params = self._prepare(request)
         response = self.client.request(
-            method=method,
+            method=request.method,
             url=url,
-            params={k: v for k, v in combined.items() if v is not None},
+            params=params,
         )
-        response.raise_for_status()
-        return response.content if raw else response.json()
+        return self._parse_response(response, request.raw)
 
     def get_site_list(
         self,
         size: int = 100,
         start_index: int = 0,
         search_text: str | None = None,
-        sort_property: Literal[
-            "Name",
-            "Country",
-            "State",
-            "City",
-            "Address",
-            "Zip",
-            "Status",
-            "PeakPower",
-            "InstallationDate",
-            "Amount",
-            "MaxSeverity",
-            "CreationTime",
-        ]
-        | None = None,
-        sort_order: Literal["ASC", "DESC"] = "ASC",
-        status: list[Literal["Active", "Pending", "Disabled"]]
-        | Literal["All"]
-        | None = None,
+        sort_property: SiteSortProperty | None = None,
+        sort_order: SortOrder = "ASC",
+        status: list[SiteStatus] | Literal["All"] | None = None,
     ) -> dict:
         """Return a paginated list of sites for the account (sync).
 
@@ -736,24 +460,10 @@ class MonitoringClient(BaseMonitoringClient):
             sort_order: Sort order ("ASC" or "DESC")
             status: Site status filter (["Active", "Pending"] by default)
         """
-        if status is None:
-            status = ["Active", "Pending"]
-
-        path = "sites/list"
-        params = {
-            "size": size,
-            "startIndex": start_index,
-            "sortOrder": sort_order,
-            "status": status if status == "All" else ",".join(status),
-        }
-        if search_text:
-            params["searchText"] = search_text
-        if sort_property:
-            params["sortProperty"] = sort_property
-        return self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return self._send(
+            _endpoints.site_list(
+                size, start_index, search_text, sort_property, sort_order, status
+            )
         )
 
     def get_site_details(self, site_id: int) -> dict:
@@ -761,58 +471,32 @@ class MonitoringClient(BaseMonitoringClient):
 
         Returns parsed JSON from `/site/{siteId}/details`.
         """
-        path = f"site/{site_id}/details"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.site_details(site_id))
 
     def get_site_data(self, site_ids: list[int]) -> dict:
         """Return the site's energy data period (start/end) (sync)."""
-        if len(site_ids) > 100:
-            raise ValueError("Cannot request data for more than 100 sites at once.")
-        path = f"site/{','.join(map(str, site_ids))}/dataPeriod"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.site_data(site_ids))
 
     def get_energy(
         self,
         site_ids: list[int],
         start_date: datetime,
         end_date: datetime,
-        time_unit: Literal[
-            "QUARTER_OF_AN_HOUR", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"
-        ] = "DAY",
+        time_unit: TimeUnit = "DAY",
     ) -> dict:
         """Get aggregated energy for a site between two dates (sync).
 
         this endpoint returns the same energy measurements
         that appear in the Site Dashboard.
         """
-        self._validate_timeframe(time_unit, start_date, end_date)
-
-        path = f"site/{','.join(map(str, site_ids))}/energy"
-        params = {
-            "startDate": start_date.strftime("%Y-%m-%d"),
-            "endDate": end_date.strftime("%Y-%m-%d"),
-            "timeUnit": time_unit,
-        }
-        return self._make_request(
-            method="GET",
-            path=path,
-            params=params,
-        )
+        return self._send(_endpoints.energy(site_ids, start_date, end_date, time_unit))
 
     def get_time_frame_energy(
         self,
         site_ids: list[int],
         start_date: datetime,
         end_date: datetime,
-        time_unit: Literal[
-            "QUARTER_OF_AN_HOUR", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"
-        ] = "DAY",
+        time_unit: TimeUnit = "DAY",
     ) -> dict:
         """Get time-frame energy (sync).
 
@@ -820,18 +504,8 @@ class MonitoringClient(BaseMonitoringClient):
         In sites with storage/backup, this may mean that results can differ from what appears in the Site Dashboard.
         Use the regular Site Energy API to obtain results that match the Site Dashboard calculation.
         """  # noqa: E501
-        self._validate_timeframe(time_unit, start_date, end_date)
-
-        path = f"site/{','.join(map(str, site_ids))}/timeFrameEnergy"
-        params = {
-            "startDate": start_date.strftime("%Y-%m-%d"),
-            "endDate": end_date.strftime("%Y-%m-%d"),
-            "timeUnit": time_unit,
-        }
-        return self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return self._send(
+            _endpoints.time_frame_energy(site_ids, start_date, end_date, time_unit)
         )
 
     def get_power(
@@ -841,57 +515,22 @@ class MonitoringClient(BaseMonitoringClient):
         end_time: datetime,
     ) -> dict:
         """Return power measurements (15-minute resolution) for a timeframe (sync)."""
-        self._validate_timeframe("QUARTER_OF_AN_HOUR", start_time, end_time)
-
-        path = f"site/{site_id}/power"
-        params = {
-            "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-        }
-        return self._make_request(
-            method="GET",
-            path=path,
-            params=params,
-        )
+        return self._send(_endpoints.power(site_id, start_time, end_time))
 
     def get_overview(self, site_ids: list[int]) -> dict:
         """Return a site overview (sync)."""
-        path = f"site/{','.join(map(str, site_ids))}/overview"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.overview(site_ids))
 
     def get_power_details(
         self,
         site_id: int,
         start_time: datetime,
         end_time: datetime,
-        meters: Iterable[
-            Literal[
-                "Production",
-                "Consumption",
-                "SelfConsumption",
-                "FeedIn",
-                "Purchased",
-            ]
-        ]
-        | None = None,
+        meters: Iterable[Meter] | None = None,
     ) -> dict:
         """Return detailed power measurements including optional meters (sync)."""
-        self._validate_timeframe("QUARTER_OF_AN_HOUR", start_time, end_time)
-
-        path = f"site/{site_id}/powerDetails"
-        params = {
-            "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-        }
-        if meters:
-            params["meters"] = ",".join(meters)
-        return self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return self._send(
+            _endpoints.power_details(site_id, start_time, end_time, meters)
         )
 
     def get_energy_details(
@@ -899,44 +538,17 @@ class MonitoringClient(BaseMonitoringClient):
         site_id: int,
         start_time: datetime,
         end_time: datetime,
-        meters: Iterable[
-            Literal[
-                "Production",
-                "Consumption",
-                "SelfConsumption",
-                "FeedIn",
-                "Purchased",
-            ]
-        ]
-        | None = None,
-        time_unit: Literal[
-            "QUARTER_OF_AN_HOUR", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"
-        ] = "DAY",
+        meters: Iterable[Meter] | None = None,
+        time_unit: TimeUnit = "DAY",
     ) -> dict:
         """Return detailed energy breakdown (by meter/timeUnit) (sync)."""
-        self._validate_timeframe(time_unit, start_time, end_time)
-
-        path = f"site/{site_id}/energyDetails"
-        params = {
-            "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "timeUnit": time_unit,
-        }
-        if meters:
-            params["meters"] = ",".join(meters)
-        return self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return self._send(
+            _endpoints.energy_details(site_id, start_time, end_time, meters, time_unit)
         )
 
     def get_current_power_flow(self, site_id: int) -> dict:
         """Return the current power flow (sync)."""
-        path = f"site/{site_id}/currentPowerFlow"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.current_power_flow(site_id))
 
     def get_storage_data(
         self,
@@ -946,19 +558,8 @@ class MonitoringClient(BaseMonitoringClient):
         serials: Iterable[str] | None = None,
     ) -> dict:
         """Return storage (battery) measurements for the timeframe (sync)."""
-        self._validate_timeframe("_ONE_WEEK_MAX", start_time, end_time)
-
-        path = f"site/{site_id}/storageData"
-        params = {
-            "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-        }
-        if serials:
-            params["serials"] = ",".join(serials)
-        return self._make_request(
-            method="GET",
-            path=path,
-            params=params,
+        return self._send(
+            _endpoints.storage_data(site_id, start_time, end_time, serials)
         )
 
     def get_site_user_image(
@@ -969,36 +570,18 @@ class MonitoringClient(BaseMonitoringClient):
         max_height: int | None = None,
         hash: int | None = None,  # noqa: A002 - mirrors the API's parameter name
     ) -> bytes:
-        """Return the site image (async)."""
-        if name is None:
-            path = f"site/{site_id}/image"
-        else:
-            path = f"site/{site_id}/image/{name}"
-        return self._make_request(
-            method="GET",
-            path=path,
-            raw=True,
-            params={
-                "maxWidth": max_width,
-                "maxHeight": max_height,
-                "hash": hash,
-            },
+        """Return the site image (sync)."""
+        return self._send(
+            _endpoints.site_user_image(site_id, name, max_width, max_height, hash)
         )
 
     def get_environmental_benefits(
         self,
         site_id: int,
-        system_units: Literal["Metrics", "Imperial"] | None = None,
+        system_units: SystemUnits | None = None,
     ) -> dict:
-        """Return the environmental benefits (async)."""
-        path = f"site/{site_id}/envBenefits"
-        return self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "systemUnits": system_units,
-            },
-        )
+        """Return the environmental benefits (sync)."""
+        return self._send(_endpoints.environmental_benefits(site_id, system_units))
 
     def get_site_installer_image(
         self,
@@ -1006,34 +589,18 @@ class MonitoringClient(BaseMonitoringClient):
         name: str | None = None,
     ) -> bytes:
         """Return the site installer image (sync)."""
-        if name is None:
-            path = f"site/{site_id}/installerImage"
-        else:
-            path = f"site/{site_id}/installerImage/{name}"
-        return self._make_request(
-            method="GET",
-            path=path,
-            raw=True,
-        )
+        return self._send(_endpoints.site_installer_image(site_id, name))
 
     def get_components_list(self, site_id: int) -> dict:
         """Return a list of inverters/SMIs in the specific site. (sync)."""
-        path = f"equipment/{site_id}/list"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.components_list(site_id))
 
     def get_inventory(self, site_id: int) -> dict:
         """Return the inventory of SolarEdge equipment in the site (sync).
 
         Including inverters/SMIs, batteries, meters, gateways and sensors.
         """
-        path = f"site/{site_id}/inventory"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.inventory(site_id))
 
     def get_inverter_technical_data(
         self,
@@ -1043,15 +610,10 @@ class MonitoringClient(BaseMonitoringClient):
         end_time: datetime,
     ) -> dict:
         """Return specific inverter data for a given timeframe (sync)."""
-        self._validate_timeframe("_ONE_WEEK_MAX", start_time, end_time)
-        path = f"site/{site_id}/inverter/{serial_number}/data"
-        return self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-                "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-            },
+        return self._send(
+            _endpoints.inverter_technical_data(
+                site_id, serial_number, start_time, end_time
+            )
         )
 
     def get_equipment_change_log(
@@ -1063,42 +625,21 @@ class MonitoringClient(BaseMonitoringClient):
 
         This method is applicable to inverters, optimizers, batteries and gateways.
         """
-        path = f"site/{site_id}/{serial_number}/changeLog"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.equipment_change_log(site_id, serial_number))
 
     def get_account_list(
         self,
         page_size: int = 100,
         start_index: int = 0,
         search_text: str | None = None,
-        sort_property: Literal[
-            "Name",
-            "country",
-            "city",
-            "address",
-            "zip",
-            "fax",
-            "phone",
-            "notes",
-        ]
-        | None = None,
-        sort_order: Literal["ASC", "DESC"] = "ASC",
+        sort_property: AccountSortProperty | None = None,
+        sort_order: SortOrder = "ASC",
     ) -> dict:
         """Return the account and list of sub-accounts (sync)."""
-        path = "accounts/list"
-        return self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "pageSize": min(page_size, 100),
-                "startIndex": start_index,
-                "searchText": search_text,
-                "sortProperty": sort_property,
-                "sortOrder": sort_order,
-            },
+        return self._send(
+            _endpoints.account_list(
+                page_size, start_index, search_text, sort_property, sort_order
+            )
         )
 
     def get_meters(
@@ -1106,44 +647,21 @@ class MonitoringClient(BaseMonitoringClient):
         site_id: int,
         start_time: datetime,
         end_time: datetime,
-        time_unit: Literal[
-            "QUARTER_OF_AN_HOUR", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"
-        ] = "DAY",
-        meters: Iterable[
-            Literal[
-                "Production",
-                "Consumption",
-                "FeedIn",
-                "Purchased",
-            ]
-        ]
-        | None = None,
+        time_unit: TimeUnit = "DAY",
+        meters: Iterable[MeterReading] | None = None,
     ) -> dict:
         """Return a list of meters in the specific site. (sync).
 
         Returns for each meter on site its lifetime energy reading,
         metadata and the device to which it's connected to.
         """
-        self._validate_timeframe(time_unit, start_time, end_time)
-        path = f"site/{site_id}/meters"
-        return self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "startTime": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-                "endTime": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-                "timeUnit": time_unit,
-                "meters": ",".join(meters) if meters else None,
-            },
+        return self._send(
+            _endpoints.meters(site_id, start_time, end_time, time_unit, meters)
         )
 
     def get_sensor_list(self, site_id: int) -> dict:
         """Returns a list of all the sensors in the site, and the device to which they are connected.  (sync)."""  # noqa: E501
-        path = f"equipment/{site_id}/sensors"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.sensor_list(site_id))
 
     def get_sensor_data(
         self,
@@ -1152,29 +670,12 @@ class MonitoringClient(BaseMonitoringClient):
         end_date: datetime,
     ) -> dict:
         """Returns the data of all the sensors in the site, by the gateway they are connected to. (sync)."""  # noqa: E501
-        self._validate_timeframe("_ONE_WEEK_MAX", start_date, end_date)
-        path = f"equipment/{site_id}/sensors"
-        return self._make_request(
-            method="GET",
-            path=path,
-            params={
-                "startTime": start_date.strftime("%Y-%m-%dT%H:%M:%S"),
-                "endTime": end_date.strftime("%Y-%m-%dT%H:%M:%S"),
-            },
-        )
+        return self._send(_endpoints.sensor_data(site_id, start_date, end_date))
 
     def get_current_api_version(self) -> dict:
         """Returns the current API version. (sync)."""
-        path = "version/current"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.current_api_version())
 
     def get_supported_api_versions(self) -> dict:
         """Returns a list of supported API versions. (sync)."""
-        path = "version/supported"
-        return self._make_request(
-            method="GET",
-            path=path,
-        )
+        return self._send(_endpoints.supported_api_versions())


### PR DESCRIPTION
Closes #101.

## What changed

Both clients exposed the same 24 endpoints, byte-identical apart from `async`/`await`, so every path- or param-building bug had to be found and fixed twice.

This adds `_endpoints.py`: a pure, I/O-free module where each endpoint is a function that validates its arguments, assembles the path and query params, and returns a `Request`. Both clients become thin transport wrappers — build a `Request`, send it.

Request preparation (URL build, param merge, `None` stripping) and response handling (`raise_for_status`, bytes-vs-JSON) also move to `BaseMonitoringClient`, since only the actual `await` differs between the two. Worth noting: **both bugs fixed in #106 lived in exactly this code**, duplicated per class. It's now single-source.

The repeated `Literal` unions are hoisted into named aliases (`TimeUnit`, `Meter`, `SiteSortProperty`, …) defined once in `_endpoints.py` and reused in both clients' signatures — otherwise the endpoint layer would just have become a third copy of them.

## Honest accounting of the payoff

**Duplicated client code halves: 477/479 lines per class down to 238/232.** That's the real result, and it's where bug risk lives.

**Total lines move much less: 1180 → 1098.** The endpoint module is 412 lines of new code, so most of what's removed from `monitoring.py` reappears there, once instead of twice. If you were expecting the file count to collapse, it doesn't — signatures and docstrings must stay duplicated for both clients to keep real type hints and IDE support, and those are ~230 of the ~460 lines per class.

## Public API is unchanged — verified mechanically

Not asserted, checked:

- **Same 50 public methods**, same names, same parameter names, defaults and order.
- **`typing.get_type_hints` resolves every one of the 50 to identical types before and after.** The rendered signature now shows `TimeUnit` instead of the expanded `Literal[...]`, but it resolves to exactly the same type, so type checkers see no change. The only user-visible difference is `help()`/IDE hover showing the alias name.
- **The 72-test suite is unmodified.** Not one assertion was touched — that's deliberate, so its passing is independent evidence the refactor preserved behaviour rather than tests bent to fit new code. `_validate_timeframe` is kept on the base class as a delegate specifically so no test needed changing.

Coverage rises 96% → 98%, since the endpoint layer is now directly exercised.

## Behaviour deliberately preserved, not "improved"

A few things looked like they wanted fixing mid-refactor; I left them alone so this stays a pure refactor:

- `get_site_list` keeps its `if search_text:` / `if sort_property:` truthiness guards rather than relying on the new `None` stripping — the guards also drop empty strings, and switching would have been a real behaviour change.
- `get_account_list` still silently clamps `page_size` with `min(page_size, 100)`, and only `get_site_data` enforces the 100-site cap. That inconsistency is #104's business.
- `get_sensor_data` still shares a path with `get_sensor_list` — that's #99, still awaiting confirmation against the live spec.

## Testing

- `uv run pytest` — 72 passed, suite unmodified
- `uv run pytest --cov` — 98%
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run pre-commit run --all-files` — all hooks pass
- Public API surface + resolved type hints diffed against pre-refactor `main` — identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8)_