### PR TITLE
feat!: library-owned exceptions and consistent argument validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,53 @@ async def main():
 asyncio.run(main())
 ```
 
+### Error Handling
+
+Every failure raises a `SolarEdgeError` subclass, so you never need to import
+`httpx` to handle one. The originating `httpx` exception is preserved as
+`__cause__` if you want the transport-level detail.
+
+```python
+from solaredge import (
+    MonitoringClient,
+    SolarEdgeAuthError,
+    SolarEdgeRateLimitError,
+    SolarEdgeError,
+)
+
+with MonitoringClient("YOUR_API_KEY") as client:
+    try:
+        sites = client.get_site_list()
+    except SolarEdgeAuthError:
+        ...  # bad or unauthorized API key
+    except SolarEdgeRateLimitError as exc:
+        ...  # exc.status_code, exc.response_body
+    except SolarEdgeError:
+        ...  # anything else this library raises
+```
+
+The hierarchy:
+
+| Exception | Raised when |
+| --- | --- |
+| `SolarEdgeError` | Base class for everything below |
+| `SolarEdgeValidationError` | Arguments rejected locally, before any request. Also a `ValueError` |
+| `SolarEdgeAPIError` | The API returned an error status |
+| `SolarEdgeAuthError` | 401 / 403 — key missing, invalid or not permitted |
+| `SolarEdgeNotFoundError` | 404 — no such site, equipment or endpoint |
+| `SolarEdgeRateLimitError` | 429 — quota or concurrency limit exceeded |
+| `SolarEdgeServerError` | 5xx — the API failed to handle a valid request |
+| `SolarEdgeResponseError` | Success status, but the body could not be parsed |
+
+`SolarEdgeAPIError` and its subclasses carry `status_code`, `response_body` and
+`url`.
+
+> **Note on API keys in URLs.** SolarEdge authenticates via an `api_key` query
+> parameter, so the key appears in every request URL. This library redacts it
+> from exception messages, but it will still be present in anything else that
+> records raw URLs — proxy logs, HTTP debug output, `httpx` event hooks. Take
+> care before sharing those.
+
 ## Rate Limiting & Best Practices
 
 - **Daily limit**: 300 requests per API Key and per site ID 

--- a/src/solaredge/__init__.py
+++ b/src/solaredge/__init__.py
@@ -1,5 +1,26 @@
 """Library to interact with SolarEdge's monitoring API."""
 
+from .exceptions import (
+    SolarEdgeError,
+    SolarEdgeAPIError,
+    SolarEdgeAuthError,
+    SolarEdgeServerError,
+    SolarEdgeNotFoundError,
+    SolarEdgeResponseError,
+    SolarEdgeRateLimitError,
+    SolarEdgeValidationError,
+)
 from .monitoring import MonitoringClient, AsyncMonitoringClient
 
-__all__ = ["AsyncMonitoringClient", "MonitoringClient"]
+__all__ = [
+    "AsyncMonitoringClient",
+    "MonitoringClient",
+    "SolarEdgeAPIError",
+    "SolarEdgeAuthError",
+    "SolarEdgeError",
+    "SolarEdgeNotFoundError",
+    "SolarEdgeRateLimitError",
+    "SolarEdgeResponseError",
+    "SolarEdgeServerError",
+    "SolarEdgeValidationError",
+]

--- a/src/solaredge/_endpoints.py
+++ b/src/solaredge/_endpoints.py
@@ -9,8 +9,10 @@ endpoint and can be thin transport wrappers around it.
 from __future__ import annotations
 
 from typing import Any, Literal, NamedTuple
-from datetime import datetime
+from datetime import datetime, timedelta
 from collections.abc import Iterable
+
+from .exceptions import SolarEdgeValidationError
 
 # Shared vocabulary for the API's enumerated values. Defined once here and
 # reused in both clients' public signatures.
@@ -90,32 +92,45 @@ def validate_timeframe(
     Raises:
         ValueError: If the range is inverted or exceeds the limit for the unit.
     """
-    day_delta = (end_date - start_date).days
+    delta = end_date - start_date
 
-    if day_delta < 0:
-        raise ValueError("End date must be after start date.")
+    if delta < timedelta(0):
+        raise SolarEdgeValidationError("End date must be after start date.")
 
     if time_unit == "_ONE_WEEK_MAX":
-        if day_delta > 7:
-            raise ValueError("The maximum date range is 1 week (7 days).")
+        if delta > timedelta(days=7):
+            raise SolarEdgeValidationError("The maximum date range is 1 week (7 days).")
 
     if time_unit in ("QUARTER_OF_AN_HOUR", "HOUR"):
-        if day_delta > 31:
-            raise ValueError(
+        if delta > timedelta(days=31):
+            raise SolarEdgeValidationError(
                 f"For time_unit {time_unit}, "
                 "the maximum date range is 1 month (31 days)."
             )
     if time_unit == "DAY":
-        if day_delta > 365:
-            raise ValueError(
+        if delta > timedelta(days=365):
+            raise SolarEdgeValidationError(
                 f"For time_unit {time_unit}, "
                 "the maximum date range is 1 year (365 days)."
             )
 
 
 def _site_ids(site_ids: Iterable[int]) -> str:
-    """Render a collection of site IDs as the API's comma-separated form."""
-    return ",".join(map(str, site_ids))
+    """Render site IDs as the API's comma-separated form, enforcing its limits.
+
+    Raises:
+        SolarEdgeValidationError: If the collection is empty or exceeds the
+            documented 100-site maximum.
+    """
+    ids = list(site_ids)
+    if not ids:
+        raise SolarEdgeValidationError("At least one site ID is required.")
+    if len(ids) > MAX_SITES_PER_REQUEST:
+        raise SolarEdgeValidationError(
+            f"Cannot request data for more than {MAX_SITES_PER_REQUEST} "
+            f"sites at once; got {len(ids)}."
+        )
+    return ",".join(map(str, ids))
 
 
 def site_list(
@@ -127,6 +142,10 @@ def site_list(
     status: list[SiteStatus] | Literal["All"] | None,
 ) -> Request:
     """Build the request for a paginated list of sites."""
+    if size > MAX_PAGE_SIZE:
+        raise SolarEdgeValidationError(
+            f"size cannot exceed {MAX_PAGE_SIZE}; got {size}."
+        )
     if status is None:
         status = ["Active", "Pending"]
 
@@ -150,8 +169,6 @@ def site_details(site_id: int) -> Request:
 
 def site_data(site_ids: list[int]) -> Request:
     """Build the request for the sites' energy data period."""
-    if len(site_ids) > MAX_SITES_PER_REQUEST:
-        raise ValueError("Cannot request data for more than 100 sites at once.")
     return Request("GET", f"site/{_site_ids(site_ids)}/dataPeriod")
 
 
@@ -350,11 +367,15 @@ def account_list(
     sort_order: SortOrder,
 ) -> Request:
     """Build the request for the account and its sub-accounts."""
+    if page_size > MAX_PAGE_SIZE:
+        raise SolarEdgeValidationError(
+            f"page_size cannot exceed {MAX_PAGE_SIZE}; got {page_size}."
+        )
     return Request(
         "GET",
         "accounts/list",
         {
-            "pageSize": min(page_size, MAX_PAGE_SIZE),
+            "pageSize": page_size,
             "startIndex": start_index,
             "searchText": search_text,
             "sortProperty": sort_property,

--- a/src/solaredge/exceptions.py
+++ b/src/solaredge/exceptions.py
@@ -1,0 +1,137 @@
+"""Exceptions raised by the SolarEdge clients.
+
+Every failure this library produces derives from :class:`SolarEdgeError`, so
+callers can handle errors without importing or depending on ``httpx``. The
+originating ``httpx`` exception is always preserved as ``__cause__`` for
+callers who do want the transport-level detail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+__all__ = [
+    "SolarEdgeAPIError",
+    "SolarEdgeAuthError",
+    "SolarEdgeError",
+    "SolarEdgeNotFoundError",
+    "SolarEdgeRateLimitError",
+    "SolarEdgeResponseError",
+    "SolarEdgeServerError",
+    "SolarEdgeValidationError",
+]
+
+_REDACTED = "REDACTED"
+
+
+def redact_url(url: httpx.URL | str) -> str:
+    """Return `url` with the api_key query value replaced.
+
+    SolarEdge authenticates by query parameter, so the key appears in every
+    request URL. Error messages are routinely pasted into bug reports, so the
+    key is masked anywhere this library renders a URL.
+    """
+    url = httpx.URL(url)
+    if "api_key" in url.params:
+        url = url.copy_set_param("api_key", _REDACTED)
+    return str(url)
+
+
+class SolarEdgeError(Exception):
+    """Base class for every error raised by this library."""
+
+
+class SolarEdgeValidationError(SolarEdgeError, ValueError):
+    """A request was rejected locally, before anything was sent.
+
+    Also subclasses :class:`ValueError`, so existing ``except ValueError``
+    handlers continue to work.
+    """
+
+
+class SolarEdgeAPIError(SolarEdgeError):
+    """The API responded with an error status.
+
+    Attributes:
+        status_code: HTTP status code returned by the API.
+        response_body: Parsed JSON body if the response carried one, else the
+            decoded text, else None.
+        url: The requested URL, with the api_key value redacted.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        response_body: Any = None,
+        url: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+        self.url = url
+
+
+class SolarEdgeAuthError(SolarEdgeAPIError):
+    """The API key was missing, invalid, or not permitted (401, 403)."""
+
+
+class SolarEdgeNotFoundError(SolarEdgeAPIError):
+    """The requested site, equipment or endpoint does not exist (404)."""
+
+
+class SolarEdgeRateLimitError(SolarEdgeAPIError):
+    """The account's request quota or concurrency limit was exceeded (429)."""
+
+
+class SolarEdgeServerError(SolarEdgeAPIError):
+    """The API failed to handle a valid request (5xx)."""
+
+
+class SolarEdgeResponseError(SolarEdgeError):
+    """The API returned a success status with a body that could not be parsed."""
+
+
+def _response_body(response: httpx.Response) -> Any:
+    """Extract the most useful representation of an error body."""
+    try:
+        return response.json()
+    except ValueError:
+        try:
+            return response.text or None
+        except UnicodeDecodeError:
+            return None
+
+
+def error_from_response(response: httpx.Response) -> SolarEdgeAPIError:
+    """Build the most specific SolarEdgeAPIError for an error response."""
+    status = response.status_code
+    body = _response_body(response)
+    url = redact_url(response.request.url) if response.request is not None else None
+
+    if status in (401, 403):
+        cls: type[SolarEdgeAPIError] = SolarEdgeAuthError
+        summary = "Authentication failed; check the API key"
+    elif status == 404:
+        cls = SolarEdgeNotFoundError
+        summary = "The requested resource was not found"
+    elif status == 429:
+        cls = SolarEdgeRateLimitError
+        summary = "Rate limit exceeded"
+    elif status >= 500:
+        cls = SolarEdgeServerError
+        summary = "The SolarEdge API failed to handle the request"
+    else:
+        cls = SolarEdgeAPIError
+        summary = "The SolarEdge API returned an error"
+
+    message = f"{summary} (HTTP {status})"
+    if url:
+        message = f"{message} for {url}"
+    if body:
+        message = f"{message}: {body}"
+
+    return cls(message, status_code=status, response_body=body, url=url)

--- a/src/solaredge/monitoring.py
+++ b/src/solaredge/monitoring.py
@@ -23,6 +23,11 @@ from ._endpoints import (
     ValidatedTimeUnit,
     AccountSortProperty,
 )
+from .exceptions import (
+    SolarEdgeResponseError,
+    redact_url,
+    error_from_response,
+)
 
 DEFAULT_BASE_URL = "https://monitoringapi.solaredge.com"
 MAX_CONCURRENT_REQUESTS = 3
@@ -75,9 +80,26 @@ class BaseMonitoringClient(ABC):  # noqa: B024 - shared helpers, not an interfac
 
     @staticmethod
     def _parse_response(response: httpx.Response, raw: bool) -> Any:
-        """Raise for error status, then return raw bytes or parsed JSON."""
-        response.raise_for_status()
-        return response.content if raw else response.json()
+        """Return raw bytes or parsed JSON, translating failures.
+
+        Raises a SolarEdgeError subclass rather than an httpx exception, so
+        callers never need to depend on this library's transport. The original
+        httpx error is preserved as __cause__.
+        """
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise error_from_response(response) from exc
+
+        if raw:
+            return response.content
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise SolarEdgeResponseError(
+                f"The API returned a non-JSON body (HTTP {response.status_code}) "
+                f"for {redact_url(response.request.url)}"
+            ) from exc
 
 
 class AsyncMonitoringClient(BaseMonitoringClient):
@@ -126,9 +148,13 @@ class AsyncMonitoringClient(BaseMonitoringClient):
             await self.client.aclose()
 
     async def aclose(self) -> None:
-        """Close the internal httpx.Client if owned by this instance."""
+        """Close the internal httpx.AsyncClient if this instance created it.
+
+        Does nothing when the client was supplied by the caller, who owns its
+        lifetime. This matches __aexit__, which no-ops in the same case.
+        """
         if self._external_client:
-            raise ValueError("Will not close externally provided httpx.Client.")
+            return
         await self.client.aclose()
 
     async def _send(self, request: Request) -> Any:
@@ -269,11 +295,19 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         name: str | None = None,
         max_width: int | None = None,
         max_height: int | None = None,
-        hash: int | None = None,  # noqa: A002 - mirrors the API's parameter name
+        image_hash: int | None = None,
     ) -> bytes:
-        """Return the site image (async)."""
+        """Return the site image (async).
+
+        Args:
+            site_id: The site to fetch the image for.
+            name: Optional image name; the default image is returned without it.
+            max_width: Optional maximum width in pixels.
+            max_height: Optional maximum height in pixels.
+            image_hash: Optional cache-validation hash (the API's `hash` param).
+        """
         return await self._send(
-            _endpoints.site_user_image(site_id, name, max_width, max_height, hash)
+            _endpoints.site_user_image(site_id, name, max_width, max_height, image_hash)
         )
 
     async def get_environmental_benefits(
@@ -425,9 +459,13 @@ class MonitoringClient(BaseMonitoringClient):
             self.client.close()
 
     def close(self) -> None:
-        """Close the internal httpx.Client if owned by this instance."""
+        """Close the internal httpx.Client if this instance created it.
+
+        Does nothing when the client was supplied by the caller, who owns its
+        lifetime. This matches __exit__, which no-ops in the same case.
+        """
         if self._external_client:
-            raise ValueError("Will not close externally provided httpx.Client.")
+            return
         self.client.close()
 
     def _send(self, request: Request) -> Any:
@@ -568,11 +606,19 @@ class MonitoringClient(BaseMonitoringClient):
         name: str | None = None,
         max_width: int | None = None,
         max_height: int | None = None,
-        hash: int | None = None,  # noqa: A002 - mirrors the API's parameter name
+        image_hash: int | None = None,
     ) -> bytes:
-        """Return the site image (sync)."""
+        """Return the site image (sync).
+
+        Args:
+            site_id: The site to fetch the image for.
+            name: Optional image name; the default image is returned without it.
+            max_width: Optional maximum width in pixels.
+            max_height: Optional maximum height in pixels.
+            image_hash: Optional cache-validation hash (the API's `hash` param).
+        """
         return self._send(
-            _endpoints.site_user_image(site_id, name, max_width, max_height, hash)
+            _endpoints.site_user_image(site_id, name, max_width, max_height, image_hash)
         )
 
     def get_environmental_benefits(

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -6,7 +6,17 @@ from datetime import datetime
 import httpx
 import pytest
 
-from solaredge import MonitoringClient, AsyncMonitoringClient
+from solaredge import (
+    MonitoringClient,
+    SolarEdgeAPIError,
+    SolarEdgeAuthError,
+    SolarEdgeServerError,
+    AsyncMonitoringClient,
+    SolarEdgeNotFoundError,
+    SolarEdgeResponseError,
+    SolarEdgeRateLimitError,
+    SolarEdgeValidationError,
+)
 
 API_KEY = "test_key"
 BASE = "https://monitoringapi.solaredge.com"
@@ -227,12 +237,12 @@ class TestClientLifecycle:
         assert not external.is_closed
         external.close()
 
-    def test_close_refuses_external_client(self):
-        """close() refuses to close a client it does not own."""
+    def test_close_leaves_external_client_open(self):
+        """close() is a no-op for a client it does not own, matching __exit__."""
         external = httpx.Client()
         client = MonitoringClient(api_key=API_KEY, client=external)
-        with pytest.raises(ValueError, match="externally provided"):
-            client.close()
+        client.close()
+        assert not external.is_closed
         external.close()
 
     def test_base_url_override_and_trailing_slash(self):
@@ -254,12 +264,12 @@ class TestClientLifecycle:
             assert client is not None
         assert client.client.is_closed
 
-    async def test_aclose_refuses_external_client(self):
-        """aclose() refuses to close a client it does not own."""
+    async def test_aclose_leaves_external_client_open(self):
+        """aclose() is a no-op for a client it does not own, matching __aexit__."""
         external = httpx.AsyncClient()
         client = AsyncMonitoringClient(api_key=API_KEY, client=external)
-        with pytest.raises(ValueError, match="externally provided"):
-            await client.aclose()
+        await client.aclose()
+        assert not external.is_closed
         await external.aclose()
 
 
@@ -411,3 +421,160 @@ class TestSiteLimits:
         client = MonitoringClient(API_KEY)
         with pytest.raises(ValueError, match="more than 100 sites"):
             client.get_site_data(site_ids=list(range(101)))
+
+
+class TestErrorTranslation:
+    """API failures surface as library-owned exceptions, never httpx ones."""
+
+    @staticmethod
+    def _client_returning(status: int, body=None, text: str | None = None):
+        def handler(request: httpx.Request) -> httpx.Response:
+            if text is not None:
+                return httpx.Response(status, text=text)
+            return httpx.Response(status, json=body if body is not None else {})
+
+        return MonitoringClient(
+            "SECRET", client=httpx.Client(transport=httpx.MockTransport(handler))
+        )
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (400, SolarEdgeAPIError),
+            (401, SolarEdgeAuthError),
+            (403, SolarEdgeAuthError),
+            (404, SolarEdgeNotFoundError),
+            (429, SolarEdgeRateLimitError),
+            (500, SolarEdgeServerError),
+            (503, SolarEdgeServerError),
+        ],
+    )
+    def test_status_maps_to_exception_type(self, status, expected):
+        """Each error status raises its most specific exception class."""
+        client = self._client_returning(status, {"String": "nope"})
+        with pytest.raises(expected) as excinfo:
+            client.get_site_details(site_id=1)
+
+        assert excinfo.value.status_code == status
+        assert excinfo.value.response_body == {"String": "nope"}
+
+    def test_every_api_error_is_a_solaredge_error(self):
+        """Callers can catch the base class alone."""
+        client = self._client_returning(500)
+        with pytest.raises(SolarEdgeAPIError):
+            client.get_site_details(site_id=1)
+
+    def test_api_key_is_redacted_from_the_message(self):
+        """A traceback must never expose a live API key."""
+        client = self._client_returning(403, {"String": "Invalid token"})
+        with pytest.raises(SolarEdgeAuthError) as excinfo:
+            client.get_site_details(site_id=1)
+
+        assert "SECRET" not in str(excinfo.value)
+        assert "SECRET" not in (excinfo.value.url or "")
+        assert "api_key=REDACTED" in str(excinfo.value)
+
+    def test_httpx_error_is_preserved_as_cause(self):
+        """The transport-level error stays reachable for callers who want it."""
+        client = self._client_returning(404)
+        with pytest.raises(SolarEdgeNotFoundError) as excinfo:
+            client.get_site_details(site_id=1)
+
+        assert isinstance(excinfo.value.__cause__, httpx.HTTPStatusError)
+
+    def test_non_json_success_body_raises_response_error(self):
+        """A 200 with an unparseable body is a library error, not a ValueError."""
+        client = self._client_returning(200, text="<html>not json</html>")
+        with pytest.raises(SolarEdgeResponseError) as excinfo:
+            client.get_site_details(site_id=1)
+
+        assert "SECRET" not in str(excinfo.value)
+
+    def test_raw_endpoints_skip_json_parsing(self):
+        """Image endpoints return bytes even when the body is not JSON."""
+        client = self._client_returning(200, text="<html>not json</html>")
+        assert client.get_site_user_image(site_id=1) == b"<html>not json</html>"
+
+    async def test_async_client_translates_errors_too(self):
+        """The async client raises the same types as the sync client."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, json={"String": "slow down"})
+
+        client = AsyncMonitoringClient(
+            "SECRET",
+            client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+        with pytest.raises(SolarEdgeRateLimitError) as excinfo:
+            await client.get_site_details(site_id=1)
+        assert excinfo.value.status_code == 429
+
+
+class TestValidation:
+    """Argument limits are enforced locally and consistently."""
+
+    def test_validation_error_is_still_a_value_error(self):
+        """Existing `except ValueError` handlers keep working."""
+        assert issubclass(SolarEdgeValidationError, ValueError)
+
+    @pytest.mark.parametrize(
+        "method",
+        ["get_site_data", "get_overview"],
+    )
+    def test_empty_site_ids_rejected(self, method):
+        """An empty list would build a malformed `site//...` path."""
+        client = MonitoringClient(API_KEY)
+        with pytest.raises(SolarEdgeValidationError, match="At least one site ID"):
+            getattr(client, method)(site_ids=[])
+
+    @pytest.mark.parametrize(
+        "method",
+        ["get_site_data", "get_overview"],
+    )
+    def test_site_cap_enforced_consistently(self, method):
+        """Every site_ids endpoint enforces the cap, not just get_site_data."""
+        client = MonitoringClient(API_KEY)
+        with pytest.raises(SolarEdgeValidationError, match="more than 100"):
+            getattr(client, method)(site_ids=list(range(101)))
+
+    def test_energy_enforces_site_cap(self):
+        """The cap applies to the dated endpoints as well."""
+        client = MonitoringClient(API_KEY)
+        with pytest.raises(SolarEdgeValidationError, match="more than 100"):
+            client.get_energy(site_ids=list(range(101)), start_date=START, end_date=END)
+
+    def test_page_size_raises_instead_of_clamping(self):
+        """get_account_list no longer silently truncates an over-large request."""
+        client = MonitoringClient(API_KEY)
+        with pytest.raises(SolarEdgeValidationError, match="page_size cannot exceed"):
+            client.get_account_list(page_size=500)
+
+    def test_site_list_size_validated(self):
+        """get_site_list documented a max of 100 but never enforced it."""
+        client = MonitoringClient(API_KEY)
+        with pytest.raises(SolarEdgeValidationError, match="size cannot exceed"):
+            client.get_site_list(size=500)
+
+    def test_partial_day_over_limit_is_rejected(self):
+        """A 7.5-day range exceeds the one-week ceiling.
+
+        The previous whole-day truncation let this through.
+        """
+        client = MonitoringClient(API_KEY)
+        with pytest.raises(SolarEdgeValidationError, match="1 week"):
+            client.get_storage_data(
+                site_id=1,
+                start_time=datetime(2024, 1, 1),
+                end_time=datetime(2024, 1, 8, 12),
+            )
+
+    def test_exactly_at_limit_is_allowed(self):
+        """The boundary itself stays valid."""
+        requests: list[httpx.Request] = []
+        client = _sync_client(requests)
+        client.get_storage_data(
+            site_id=1,
+            start_time=datetime(2024, 1, 1),
+            end_time=datetime(2024, 1, 8),
+        )
+        assert len(requests) == 1


### PR DESCRIPTION
Closes #104, closes #105.

Breaking changes, per the decision to prioritise correctness over compatibility. **This is a `2.0.0`** — see the release note at the bottom.

## Library-owned exceptions (#105)

Every failure now raises a `SolarEdgeError` subclass, so callers never need to import `httpx` to handle one — today a consumer can't catch a 403 without depending on this library's transport choice.

| Exception | Raised when |
| --- | --- |
| `SolarEdgeError` | Base for everything below |
| `SolarEdgeValidationError` | Rejected locally, before any request. **Also a `ValueError`** |
| `SolarEdgeAPIError` | The API returned an error status |
| `SolarEdgeAuthError` | 401 / 403 |
| `SolarEdgeNotFoundError` | 404 |
| `SolarEdgeRateLimitError` | 429 |
| `SolarEdgeServerError` | 5xx |
| `SolarEdgeResponseError` | Success status, unparseable body |

`SolarEdgeAPIError` carries `status_code`, `response_body` and `url`, and the original `httpx` error is chained as `__cause__` so transport detail stays reachable. `SolarEdgeValidationError` multiply-inherits `ValueError` deliberately, so existing `except ValueError` handlers keep working.

**API keys are now redacted from exception messages.** SolarEdge authenticates by query parameter, so the key is in every request URL — and tracebacks get pasted into bug reports. There's a test asserting the key never appears in a message. The README also warns that anything else recording raw URLs (proxy logs, httpx event hooks) will still contain it, since that's outside this library's control.

## Validation consistency (#104)

- **`page_size` and `size` raise instead of clamping.** `get_account_list` silently truncated 500 → 100 with no signal; `get_site_list` documented a max of 100 and never enforced it at all.
- **The 100-site cap moved into the shared site-ID helper**, so `get_energy`, `get_time_frame_energy` and `get_overview` enforce it too — previously only `get_site_data` did.
- **Empty `site_ids` rejected.** These previously built a malformed `site//energy` path that failed confusingly at the API instead of locally.
- **Timeframe checks compare `timedelta`s rather than truncated whole days.** A 7.5-day range used to slip past the one-week ceiling because `.days` truncated it to 7. There's a test for the boundary staying valid, so this didn't become off-by-one in the other direction.

## Also fixed, now that breaking is on the table

Two things I deliberately left half-done in earlier PRs *only* because a proper fix would have broken callers:

- **`hash` → `image_hash`** on `get_site_user_image`. In #106 this got a `# noqa: A002` purely to avoid breaking keyword callers; the suppression is now deleted rather than worked around.
- **`close()` / `aclose()` are no-ops for an external client** instead of raising `ValueError`. They previously raised on exactly the condition where `__exit__` / `__aexit__` silently no-op — refusing to close something you don't own isn't an error, and the two paths disagreeing was the actual bug.

## What I did *not* do

I flagged "`WEEK`/`MONTH`/`YEAR` have no range validation" as a gap in my review. Looking at it properly for this change, **that's correct behaviour** — SolarEdge documents limits only for `QUARTER_OF_AN_HOUR`/`HOUR` (1 month) and `DAY` (1 year). Inventing ceilings for the others would reject valid requests, so I left them unvalidated. My original note was wrong.

#99 is still open and still needs the real sensor-data endpoint confirmed; I won't guess at a request path.

## Testing

- `uv run pytest` — **95 passed** (72 → 95; the 23 new tests cover the exception hierarchy, redaction, `__cause__` chaining, `ValueError` compatibility, and every new validation rule including the boundary cases)
- `uv run pytest --cov` — **97%**
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run pre-commit run --all-files` — all hooks pass

Only two pre-existing tests changed: the two asserting the old `close()`/`aclose()` raise behaviour. Everything else in the suite passed untouched, which is the evidence that the breaking changes are scoped to what's described here and nothing else shifted.

## Releasing

Commits carry a `BREAKING CHANGE:` footer, so `uv run cz bump` will compute `2.0.0` and update `CHANGELOG.md` automatically. I deliberately did **not** bump the version in this PR — the repo's commitizen setup treats bumping as a separate release step on `main`, and pre-empting it here would fight that workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8)_