### PR TITLE
chore: swap pre-commit for prek

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
-# To update pre-commit hooks run:
-# uv run pre-commit autoupdate --freeze
+# Hooks are run by prek (https://github.com/j178/prek), a drop-in
+# pre-commit replacement. This file keeps the .pre-commit-config.yaml
+# name and format, so Dependabot's pre-commit ecosystem still updates it.
+#
+# To update hook revisions run:
+# uv run prek update --freeze
 
 repos:
 -   hooks:

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ for more information see [page 8](https://www.solaredge.com/sites/default/files/
 ```bash
 # Install development dependencies
 uv sync
-uv run pre-commit install -t commit-msg
+uv run prek install -t commit-msg
 ```
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,10 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["commitizen", "pre-commit"]
+dev = [
+    "commitizen",
+    "prek",
+]
 test = ["pytest", "pytest-asyncio", "pytest-cov"]
 validate = ["ruff"]
 


### PR DESCRIPTION
Closes #95.

Swaps the `pre-commit` dev dependency for [prek](https://github.com/j178/prek), a Rust reimplementation that reads the same `.pre-commit-config.yaml`. No hook definitions change, and the config file keeps its name — which matters, because Dependabot's `pre-commit` ecosystem (added in #92) reads that file directly and keeps working untouched.

## Verified before swapping

The issue flagged three things worth checking rather than assuming. All three were actually tested:

- **SHA-pinned hooks resolve.** `prek run --all-files` installs and runs all three pinned repos (`pre-commit-hooks`, `ruff-pre-commit`, `commitizen`) from their commit SHAs — the pins from #93 survive.
- **The `commitizen` commit-msg hook works.** This was the main risk, being stage-specific rather than a plain file hook. Tested both directions: a valid conventional message passes, and `this is not conventional at all` is rejected with exit code 14.
- **`--freeze` exists.** `prek update --freeze` is the equivalent of `pre-commit autoupdate --freeze`, so the SHA-pinning workflow carries over intact.

## One difference worth knowing

The subcommand is **`prek update`**, not `autoupdate`. The comment at the top of `.pre-commit-config.yaml` and the README install line are updated accordingly, so nobody follows a stale instruction.

## Testing

- `uv run prek run --all-files` — all five hooks pass
- `uv run prek run --hook-stage commit-msg` — passes valid, rejects invalid
- `uv run pytest` — 95 passed
- `uv run ruff check .` / `ruff format --check .` — clean
- `pre-commit` confirmed gone from the environment after `uv sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8)_