### PR TITLE
feat!: remove endpoints SolarEdge withdrew in March 2026

### DIFF
--- a/src/solaredge/_endpoints.py
+++ b/src/solaredge/_endpoints.py
@@ -40,17 +40,6 @@ SiteSortProperty = Literal[
     "InstallationDate",
     "Amount",
     "MaxSeverity",
-    "CreationTime",
-]
-AccountSortProperty = Literal[
-    "Name",
-    "country",
-    "city",
-    "address",
-    "zip",
-    "fax",
-    "phone",
-    "notes",
 ]
 
 # `_ONE_WEEK_MAX` is not an API time unit; it selects the one-week ceiling for
@@ -70,7 +59,6 @@ MAX_PAGE_SIZE = 100
 
 _DATE_FORMAT = "%Y-%m-%d"
 _DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 
 class Request(NamedTuple):
@@ -79,7 +67,6 @@ class Request(NamedTuple):
     method: str
     path: str
     params: dict[str, Any] | None = None
-    raw: bool = False
 
 
 def validate_timeframe(
@@ -286,27 +273,6 @@ def storage_data(
     return Request("GET", f"site/{site_id}/storageData", params)
 
 
-def site_user_image(
-    site_id: int,
-    name: str | None,
-    max_width: int | None,
-    max_height: int | None,
-    image_hash: int | None,
-) -> Request:
-    """Build the request for the site image, which returns raw bytes."""
-    path = f"site/{site_id}/image" if name is None else f"site/{site_id}/image/{name}"
-    return Request(
-        "GET",
-        path,
-        {
-            "maxWidth": max_width,
-            "maxHeight": max_height,
-            "hash": image_hash,
-        },
-        raw=True,
-    )
-
-
 def environmental_benefits(site_id: int, system_units: SystemUnits | None) -> Request:
     """Build the request for the site's environmental benefits."""
     return Request(
@@ -314,16 +280,6 @@ def environmental_benefits(site_id: int, system_units: SystemUnits | None) -> Re
         f"site/{site_id}/envBenefits",
         {"systemUnits": system_units},
     )
-
-
-def site_installer_image(site_id: int, name: str | None) -> Request:
-    """Build the request for the installer image, which returns raw bytes."""
-    path = (
-        f"site/{site_id}/installerImage"
-        if name is None
-        else f"site/{site_id}/installerImage/{name}"
-    )
-    return Request("GET", path, raw=True)
 
 
 def components_list(site_id: int) -> Request:
@@ -354,36 +310,6 @@ def inverter_technical_data(
     )
 
 
-def equipment_change_log(site_id: int, serial_number: str) -> Request:
-    """Build the request for a component's replacement history."""
-    return Request("GET", f"site/{site_id}/{serial_number}/changeLog")
-
-
-def account_list(
-    page_size: int,
-    start_index: int,
-    search_text: str | None,
-    sort_property: AccountSortProperty | None,
-    sort_order: SortOrder,
-) -> Request:
-    """Build the request for the account and its sub-accounts."""
-    if page_size > MAX_PAGE_SIZE:
-        raise SolarEdgeValidationError(
-            f"page_size cannot exceed {MAX_PAGE_SIZE}; got {page_size}."
-        )
-    return Request(
-        "GET",
-        "accounts/list",
-        {
-            "pageSize": page_size,
-            "startIndex": start_index,
-            "searchText": search_text,
-            "sortProperty": sort_property,
-            "sortOrder": sort_order,
-        },
-    )
-
-
 def meters(
     site_id: int,
     start_time: datetime,
@@ -403,31 +329,3 @@ def meters(
             "meters": ",".join(meters) if meters else None,
         },
     )
-
-
-def sensor_list(site_id: int) -> Request:
-    """Build the request for the site's sensors."""
-    return Request("GET", f"equipment/{site_id}/sensors")
-
-
-def sensor_data(site_id: int, start_date: datetime, end_date: datetime) -> Request:
-    """Build the request for sensor measurements."""
-    validate_timeframe("_ONE_WEEK_MAX", start_date, end_date)
-    return Request(
-        "GET",
-        f"equipment/{site_id}/sensors",
-        {
-            "startTime": start_date.strftime(_ISO_FORMAT),
-            "endTime": end_date.strftime(_ISO_FORMAT),
-        },
-    )
-
-
-def current_api_version() -> Request:
-    """Build the request for the current API version."""
-    return Request("GET", "version/current")
-
-
-def supported_api_versions() -> Request:
-    """Build the request for the list of supported API versions."""
-    return Request("GET", "version/supported")

--- a/src/solaredge/monitoring.py
+++ b/src/solaredge/monitoring.py
@@ -21,7 +21,6 @@ from ._endpoints import (
     MeterReading,
     SiteSortProperty,
     ValidatedTimeUnit,
-    AccountSortProperty,
 )
 from .exceptions import (
     SolarEdgeResponseError,
@@ -79,8 +78,8 @@ class BaseMonitoringClient(ABC):  # noqa: B024 - shared helpers, not an interfac
         return url, {k: v for k, v in combined.items() if v is not None}
 
     @staticmethod
-    def _parse_response(response: httpx.Response, raw: bool) -> Any:
-        """Return raw bytes or parsed JSON, translating failures.
+    def _parse_response(response: httpx.Response) -> Any:
+        """Return the parsed JSON body, translating failures.
 
         Raises a SolarEdgeError subclass rather than an httpx exception, so
         callers never need to depend on this library's transport. The original
@@ -91,8 +90,6 @@ class BaseMonitoringClient(ABC):  # noqa: B024 - shared helpers, not an interfac
         except httpx.HTTPStatusError as exc:
             raise error_from_response(response) from exc
 
-        if raw:
-            return response.content
         try:
             return response.json()
         except ValueError as exc:
@@ -166,7 +163,7 @@ class AsyncMonitoringClient(BaseMonitoringClient):
                 url=url,
                 params=params,
             )
-            return self._parse_response(response, request.raw)
+            return self._parse_response(response)
 
     async def get_site_list(
         self,
@@ -183,7 +180,7 @@ class AsyncMonitoringClient(BaseMonitoringClient):
             size: Number of sites to return per page (max 100)
             start_index: Starting index for pagination
             search_text: Text to search for across multiple fields. The API will
-                search in: Name, Notes, Email, Country, State, City, Zip, Full address
+                search in: Name, Notes, Email, Country, State, City, Zip
             sort_property: Property to sort by
             sort_order: Sort order ("ASC" or "DESC")
             status: Site status filter (["Active", "Pending"] by default)
@@ -289,27 +286,6 @@ class AsyncMonitoringClient(BaseMonitoringClient):
             _endpoints.storage_data(site_id, start_time, end_time, serials)
         )
 
-    async def get_site_user_image(
-        self,
-        site_id: int,
-        name: str | None = None,
-        max_width: int | None = None,
-        max_height: int | None = None,
-        image_hash: int | None = None,
-    ) -> bytes:
-        """Return the site image (async).
-
-        Args:
-            site_id: The site to fetch the image for.
-            name: Optional image name; the default image is returned without it.
-            max_width: Optional maximum width in pixels.
-            max_height: Optional maximum height in pixels.
-            image_hash: Optional cache-validation hash (the API's `hash` param).
-        """
-        return await self._send(
-            _endpoints.site_user_image(site_id, name, max_width, max_height, image_hash)
-        )
-
     async def get_environmental_benefits(
         self,
         site_id: int,
@@ -319,14 +295,6 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         return await self._send(
             _endpoints.environmental_benefits(site_id, system_units)
         )
-
-    async def get_site_installer_image(
-        self,
-        site_id: int,
-        name: str | None = None,
-    ) -> bytes:
-        """Return the site installer image (async)."""
-        return await self._send(_endpoints.site_installer_image(site_id, name))
 
     async def get_components_list(self, site_id: int) -> dict:
         """Return a list of inverters/SMIs in the specific site. (async)."""
@@ -353,32 +321,6 @@ class AsyncMonitoringClient(BaseMonitoringClient):
             )
         )
 
-    async def get_equipment_change_log(
-        self,
-        site_id: int,
-        serial_number: str,
-    ) -> dict:
-        """Returns a list of equipment component replacements ordered by date (async).
-
-        This method is applicable to inverters, optimizers, batteries and gateways.
-        """
-        return await self._send(_endpoints.equipment_change_log(site_id, serial_number))
-
-    async def get_account_list(
-        self,
-        page_size: int = 100,
-        start_index: int = 0,
-        search_text: str | None = None,
-        sort_property: AccountSortProperty | None = None,
-        sort_order: SortOrder = "ASC",
-    ) -> dict:
-        """Return the account and list of sub-accounts (async)."""
-        return await self._send(
-            _endpoints.account_list(
-                page_size, start_index, search_text, sort_property, sort_order
-            )
-        )
-
     async def get_meters(
         self,
         site_id: int,
@@ -395,27 +337,6 @@ class AsyncMonitoringClient(BaseMonitoringClient):
         return await self._send(
             _endpoints.meters(site_id, start_time, end_time, time_unit, meters)
         )
-
-    async def get_sensor_list(self, site_id: int) -> dict:
-        """Returns a list of all the sensors in the site, and the device to which they are connected.  (async)."""  # noqa: E501
-        return await self._send(_endpoints.sensor_list(site_id))
-
-    async def get_sensor_data(
-        self,
-        site_id: int,
-        start_date: datetime,
-        end_date: datetime,
-    ) -> dict:
-        """Returns the data of all the sensors in the site, by the gateway they are connected to. (async)."""  # noqa: E501
-        return await self._send(_endpoints.sensor_data(site_id, start_date, end_date))
-
-    async def get_current_api_version(self) -> dict:
-        """Returns the current API version. (async)."""
-        return await self._send(_endpoints.current_api_version())
-
-    async def get_supported_api_versions(self) -> dict:
-        """Returns a list of supported API versions. (async)."""
-        return await self._send(_endpoints.supported_api_versions())
 
 
 class MonitoringClient(BaseMonitoringClient):
@@ -476,7 +397,7 @@ class MonitoringClient(BaseMonitoringClient):
             url=url,
             params=params,
         )
-        return self._parse_response(response, request.raw)
+        return self._parse_response(response)
 
     def get_site_list(
         self,
@@ -493,7 +414,7 @@ class MonitoringClient(BaseMonitoringClient):
             size: Number of sites to return per page (max 100)
             start_index: Starting index for pagination
             search_text: Text to search for across multiple fields. The API will
-                search in: Name, Notes, Email, Country, State, City, Zip, Full address
+                search in: Name, Notes, Email, Country, State, City, Zip
             sort_property: Property to sort by
             sort_order: Sort order ("ASC" or "DESC")
             status: Site status filter (["Active", "Pending"] by default)
@@ -600,27 +521,6 @@ class MonitoringClient(BaseMonitoringClient):
             _endpoints.storage_data(site_id, start_time, end_time, serials)
         )
 
-    def get_site_user_image(
-        self,
-        site_id: int,
-        name: str | None = None,
-        max_width: int | None = None,
-        max_height: int | None = None,
-        image_hash: int | None = None,
-    ) -> bytes:
-        """Return the site image (sync).
-
-        Args:
-            site_id: The site to fetch the image for.
-            name: Optional image name; the default image is returned without it.
-            max_width: Optional maximum width in pixels.
-            max_height: Optional maximum height in pixels.
-            image_hash: Optional cache-validation hash (the API's `hash` param).
-        """
-        return self._send(
-            _endpoints.site_user_image(site_id, name, max_width, max_height, image_hash)
-        )
-
     def get_environmental_benefits(
         self,
         site_id: int,
@@ -628,14 +528,6 @@ class MonitoringClient(BaseMonitoringClient):
     ) -> dict:
         """Return the environmental benefits (sync)."""
         return self._send(_endpoints.environmental_benefits(site_id, system_units))
-
-    def get_site_installer_image(
-        self,
-        site_id: int,
-        name: str | None = None,
-    ) -> bytes:
-        """Return the site installer image (sync)."""
-        return self._send(_endpoints.site_installer_image(site_id, name))
 
     def get_components_list(self, site_id: int) -> dict:
         """Return a list of inverters/SMIs in the specific site. (sync)."""
@@ -662,32 +554,6 @@ class MonitoringClient(BaseMonitoringClient):
             )
         )
 
-    def get_equipment_change_log(
-        self,
-        site_id: int,
-        serial_number: str,
-    ) -> dict:
-        """Returns a list of equipment component replacements ordered by date (sync).
-
-        This method is applicable to inverters, optimizers, batteries and gateways.
-        """
-        return self._send(_endpoints.equipment_change_log(site_id, serial_number))
-
-    def get_account_list(
-        self,
-        page_size: int = 100,
-        start_index: int = 0,
-        search_text: str | None = None,
-        sort_property: AccountSortProperty | None = None,
-        sort_order: SortOrder = "ASC",
-    ) -> dict:
-        """Return the account and list of sub-accounts (sync)."""
-        return self._send(
-            _endpoints.account_list(
-                page_size, start_index, search_text, sort_property, sort_order
-            )
-        )
-
     def get_meters(
         self,
         site_id: int,
@@ -704,24 +570,3 @@ class MonitoringClient(BaseMonitoringClient):
         return self._send(
             _endpoints.meters(site_id, start_time, end_time, time_unit, meters)
         )
-
-    def get_sensor_list(self, site_id: int) -> dict:
-        """Returns a list of all the sensors in the site, and the device to which they are connected.  (sync)."""  # noqa: E501
-        return self._send(_endpoints.sensor_list(site_id))
-
-    def get_sensor_data(
-        self,
-        site_id: int,
-        start_date: datetime,
-        end_date: datetime,
-    ) -> dict:
-        """Returns the data of all the sensors in the site, by the gateway they are connected to. (sync)."""  # noqa: E501
-        return self._send(_endpoints.sensor_data(site_id, start_date, end_date))
-
-    def get_current_api_version(self) -> dict:
-        """Returns the current API version. (sync)."""
-        return self._send(_endpoints.current_api_version())
-
-    def get_supported_api_versions(self) -> dict:
-        """Returns a list of supported API versions. (sync)."""
-        return self._send(_endpoints.supported_api_versions())

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -31,8 +31,6 @@ DATE_END = "2024-01-05"
 TIME_START = "2024-01-01 00:00:00"
 TIME_END = "2024-01-05 00:00:00"
 
-IMAGE_BYTES = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
-
 # (method name, kwargs, expected path, expected query params minus api_key)
 ENDPOINTS: list[tuple[str, dict[str, Any], str, dict[str, str]]] = [
     (
@@ -141,32 +139,11 @@ ENDPOINTS: list[tuple[str, dict[str, Any], str, dict[str, str]]] = [
         {"startTime": TIME_START, "endTime": TIME_END},
     ),
     (
-        "get_equipment_change_log",
-        {"site_id": 1, "serial_number": "SN1"},
-        "/site/1/SN1/changeLog",
-        {},
-    ),
-    (
-        "get_account_list",
-        {},
-        "/accounts/list",
-        {"pageSize": "100", "startIndex": "0", "sortOrder": "ASC"},
-    ),
-    (
         "get_meters",
         {"site_id": 1, "start_time": START, "end_time": END},
         "/site/1/meters",
         {"startTime": TIME_START, "endTime": TIME_END, "timeUnit": "DAY"},
     ),
-    ("get_sensor_list", {"site_id": 1}, "/equipment/1/sensors", {}),
-    (
-        "get_sensor_data",
-        {"site_id": 1, "start_date": START, "end_date": END},
-        "/equipment/1/sensors",
-        {"startTime": "2024-01-01T00:00:00", "endTime": "2024-01-05T00:00:00"},
-    ),
-    ("get_current_api_version", {}, "/version/current", {}),
-    ("get_supported_api_versions", {}, "/version/supported", {}),
 ]
 
 IDS = [f"{name}-{i}" for i, (name, *_) in enumerate(ENDPOINTS)]
@@ -311,53 +288,6 @@ class TestEndpoints:
         assert not async_only
 
 
-class TestImageEndpoints:
-    """Image endpoints return raw bytes rather than parsed JSON."""
-
-    def test_sync_user_image_returns_bytes(self):
-        """get_site_user_image returns the response body untouched."""
-        requests: list[httpx.Request] = []
-        client = _sync_client(requests, content=IMAGE_BYTES)
-        result = client.get_site_user_image(site_id=1, max_width=100)
-
-        assert result == IMAGE_BYTES
-        _assert_request(requests[0], "/site/1/image", {"maxWidth": "100"})
-
-    def test_sync_user_image_with_name(self):
-        """A named image is requested from the /image/{name} path."""
-        requests: list[httpx.Request] = []
-        client = _sync_client(requests, content=IMAGE_BYTES)
-        client.get_site_user_image(site_id=1, name="front")
-        _assert_request(requests[0], "/site/1/image/front", {})
-
-    def test_sync_installer_image_returns_bytes(self):
-        """get_site_installer_image returns the response body untouched."""
-        requests: list[httpx.Request] = []
-        client = _sync_client(requests, content=IMAGE_BYTES)
-        result = client.get_site_installer_image(site_id=1)
-
-        assert result == IMAGE_BYTES
-        _assert_request(requests[0], "/site/1/installerImage", {})
-
-    async def test_async_user_image_returns_bytes(self):
-        """The async image endpoint also returns raw bytes."""
-        requests: list[httpx.Request] = []
-        client = _async_client(requests, content=IMAGE_BYTES)
-        result = await client.get_site_user_image(site_id=1)
-
-        assert result == IMAGE_BYTES
-        _assert_request(requests[0], "/site/1/image", {})
-
-    async def test_async_installer_image_returns_bytes(self):
-        """The async installer image endpoint also returns raw bytes."""
-        requests: list[httpx.Request] = []
-        client = _async_client(requests, content=IMAGE_BYTES)
-        result = await client.get_site_installer_image(site_id=1, name="logo")
-
-        assert result == IMAGE_BYTES
-        _assert_request(requests[0], "/site/1/installerImage/logo", {})
-
-
 class TestTimeframeValidation:
     """Timeframe limits produce readable errors."""
 
@@ -490,11 +420,6 @@ class TestErrorTranslation:
 
         assert "SECRET" not in str(excinfo.value)
 
-    def test_raw_endpoints_skip_json_parsing(self):
-        """Image endpoints return bytes even when the body is not JSON."""
-        client = self._client_returning(200, text="<html>not json</html>")
-        assert client.get_site_user_image(site_id=1) == b"<html>not json</html>"
-
     async def test_async_client_translates_errors_too(self):
         """The async client raises the same types as the sync client."""
 
@@ -542,12 +467,6 @@ class TestValidation:
         client = MonitoringClient(API_KEY)
         with pytest.raises(SolarEdgeValidationError, match="more than 100"):
             client.get_energy(site_ids=list(range(101)), start_date=START, end_date=END)
-
-    def test_page_size_raises_instead_of_clamping(self):
-        """get_account_list no longer silently truncates an over-large request."""
-        client = MonitoringClient(API_KEY)
-        with pytest.raises(SolarEdgeValidationError, match="page_size cannot exceed"):
-            client.get_account_list(page_size=500)
 
     def test_site_list_size_validated(self):
         """get_site_list documented a max of 100 but never enforced it."""


### PR DESCRIPTION
Closes #110, closes #99.

Removes the eight methods targeting endpoints SolarEdge withdrew in March 2026, which now return HTTP 410.

## Removed

From both `MonitoringClient` and `AsyncMonitoringClient` (16 methods total):

| Method | Endpoint |
| --- | --- |
| `get_sensor_list` | `equipment/{siteId}/sensors` |
| `get_sensor_data` | `site/{siteId}/sensors` |
| `get_site_user_image` | `site/{siteId}/image` |
| `get_site_installer_image` | `site/{siteId}/installerImage` |
| `get_equipment_change_log` | `site/{siteId}/{sn}/changeLog` |
| `get_account_list` | `accounts/list` |
| `get_current_api_version` | `version/current` |
| `get_supported_api_versions` | `version/supported` |

The public surface goes from 25 to 17 members per client.

## This also closes #99

`get_sensor_data` had three separate defects, not one: it requested `equipment/{id}/sensors` instead of `site/{id}/sensors`, sent `startTime`/`endTime` instead of `startDate`/`endDate`, and formatted timestamps with a `T` separator instead of a space. All three are documented on #99 for the record — but repairing the address of a withdrawn endpoint is wasted work, so the method is removed rather than fixed.

## Dead code removed with them

Three things existed *only* to serve the removed endpoints and are now gone:

- **The raw-bytes request path.** `Request.raw` and the `raw` branch of `_parse_response` were used by nothing except the two image endpoints. `_parse_response` is now simply "parse JSON or translate the failure."
- **`AccountSortProperty`** — only `account_list` used it.
- **`_ISO_FORMAT`** — only sensor data used it.

## Two smaller items from the same API revision

- **`CreationTime` dropped from `SiteSortProperty`.** It is no longer an accepted sort option, so leaving it in the literal would let callers pass a value the API rejects.
- **`get_site_list`'s docstring no longer claims `searchText` covers "Full address."** It doesn't any more.

## On the evidence

Worth restating plainly, since this deletes a third of the library: I could **not** read SolarEdge's primary documentation — every SolarEdge domain is blocked by the egress proxy in the environment this was developed in, including the official PDF, the knowledge-center mirror, and third-party mirrors.

What I have is: the deprecation itself is well evidenced (home-assistant/core#177374 shows real users receiving HTTP 410 with SolarEdge pointing them at a legacy-API interest form), and the specific endpoint list comes from multiple independent sources consistently citing the March 2026 revision.

This proceeds on the maintainer's explicit instruction to remove them. If the list turns out to be wrong, this commit is a clean single revert — nothing else in the diff depends on the removals.

## Testing

- `uv run pytest` — **76 passed** (95 → 76; the 19 removed tests are exactly those covering the removed endpoints)
- `uv run pytest --cov` — **97%**, unchanged
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run prek run --all-files` — all hooks pass
- Asserted at runtime that neither client still exposes any removed method, that `Request` no longer carries `raw`, and that `CreationTime` is gone from the sort literal

## Releasing

Carries a `BREAKING CHANGE:` footer. If #108 has not been released yet, `cz bump` will fold both into one `2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8)_