### PR TITLE
bump: version 1.1.1 -> 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 2.0.0 (2026-09-06)
+
+### BREAKING CHANGE
+
+- the eight methods listed above are removed. Calls to
+them now raise AttributeError rather than reaching an endpoint that
+returns HTTP 410. SiteSortProperty no longer accepts "CreationTime".
+Request.raw is gone and _parse_response no longer takes a raw argument,
+both internal.
+- get_account_list(page_size=...) and get_site_list(size=...)
+now raise SolarEdgeValidationError above 100 instead of silently clamping or
+ignoring the limit. Validation failures raise SolarEdgeValidationError rather
+than plain ValueError; it subclasses ValueError, so existing `except
+ValueError` handlers still work, but `except Exception as e: type(e)` checks
+will see the new class. API errors raise SolarEdgeAPIError subclasses instead
+of httpx.HTTPStatusError. get_site_user_image's `hash` parameter is renamed to
+`image_hash`, which breaks callers passing it by keyword. close() and aclose()
+are now no-ops for an externally provided client instead of raising ValueError,
+matching what __exit__ and __aexit__ already did. Ranges that exceed a limit by
+a partial day are now correctly rejected.
+
+### Feat
+
+- remove endpoints SolarEdge withdrew in March 2026 (#111)
+- library-owned exceptions and consistent argument validation (#108)
+
+### Fix
+
+- request-handling bugs, test suite, py.typed, ruff rule selection (#106)
+- remove .svg from remaining badge URLs
+- update badge URLs to remove .svg extensions
+
+### Refactor
+
+- **monitoring**: extract shared endpoint layer (#107)
+
 ## 1.1.1 (2025-08-31)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 authors = [{ name = "evworth", email = "elliotworth@protonmail.com"}]
 license = {text = "MIT"}
 name = "solaredge"
-version = "1.1.1"
+version = "2.0.0"
 description = "A Python client library for the SolarEdge Monitoring API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release bump for 2.0.0. Generated by commitizen, which computed **MAJOR** from the `BREAKING CHANGE:` footers on #108 and #111.

Only `pyproject.toml` (version) and `CHANGELOG.md` change — no source edits.

## Run with `--files-only` on purpose

A plain `cz bump` also creates the `2.0.0` git tag pointing at the commit it makes. Because this lands via **squash merge**, that commit never reaches `main` — the tag would point at an orphaned branch commit, and `main` would carry a 2.0.0 release with no tag on it.

So this generated the file changes only. **The tag needs to be created on `main` after this merges:**

```bash
git checkout main && git pull
git tag 2.0.0 && git push origin 2.0.0
```

No rush on it — `pypi-publish.yaml` triggers on `workflow_dispatch` only (its tag trigger is commented out), so tagging won't publish anything by itself.

## What's in 2.0.0

Breaking, from the session's work:

- **Library-owned exceptions** (#105) — `SolarEdgeError` hierarchy replaces leaked `httpx.HTTPStatusError`; API keys redacted from messages
- **Validation raises rather than clamps** (#104) — `page_size`/`size` over 100, empty `site_ids`, the site cap enforced across all four `site_ids` methods
- **Eight endpoints removed** (#110, #99) — the ones SolarEdge withdrew in March 2026
- **`hash` → `image_hash`**, and `close()`/`aclose()` no-op for external clients

Non-breaking alongside it: `py.typed` so annotations reach consumers, the shared endpoint layer, and test coverage from 31% to 97%.

## Testing

- `uv run pytest` — 76 passed
- `uv run prek run --all-files` — all hooks pass
- `uv build` — builds `solaredge-2.0.0` sdist and wheel, `py.typed` confirmed present in the wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcvquBpLLZ9aAU6rvP9bV8)_